### PR TITLE
Add per-channel conversation history with auto-compaction

### DIFF
--- a/src/main/java/com/dylansbogar/griddybot/BotConfig.java
+++ b/src/main/java/com/dylansbogar/griddybot/BotConfig.java
@@ -3,6 +3,7 @@ package com.dylansbogar.griddybot;
 import com.dylansbogar.griddybot.commands.*;
 import com.dylansbogar.griddybot.entities.Reminder;
 import com.dylansbogar.griddybot.repositories.*;
+import com.dylansbogar.griddybot.utils.ConversationService;
 import com.dylansbogar.griddybot.utils.OpenRouterService;
 import com.dylansbogar.griddybot.utils.OzbargainService;
 import com.dylansbogar.griddybot.utils.YenService;
@@ -41,6 +42,7 @@ public class BotConfig {
     private final OzbargainService ozbargainService;
     private final DealHistoryRepository dealHistoryRepo;
     private final OpenRouterService openRouterService;
+    private final ConversationService conversationService;
 
     private JDA api;
 
@@ -56,7 +58,7 @@ public class BotConfig {
 
         // Each command class is defined here.
         api.addEventListener(
-                new MessageListener(dealHistoryRepo, ozbargainService, openRouterService),
+                new MessageListener(dealHistoryRepo, ozbargainService, openRouterService, conversationService),
                 new ModelCommand(openRouterService),
                 new CoinflipCommand(),
                 new DaylistCommand(daylistRepo, daylistDescriptionRepo),

--- a/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
@@ -2,6 +2,7 @@ package com.dylansbogar.griddybot.commands;
 
 import com.dylansbogar.griddybot.entities.PostedDeal;
 import com.dylansbogar.griddybot.repositories.DealHistoryRepository;
+import com.dylansbogar.griddybot.utils.ConversationService;
 import com.dylansbogar.griddybot.utils.OpenRouterService;
 import com.dylansbogar.griddybot.utils.OzbargainService;
 import net.dv8tion.jda.api.entities.Message;
@@ -23,11 +24,13 @@ public class MessageListener extends ListenerAdapter {
     public final DealHistoryRepository dealHistoryRepository;
     private final OzbargainService ozbargainService;
     private final OpenRouterService openRouterService;
+    private final ConversationService conversationService;
 
-    public MessageListener(DealHistoryRepository dealHistoryRepository, OzbargainService ozbargainService, OpenRouterService openRouterService) {
+    public MessageListener(DealHistoryRepository dealHistoryRepository, OzbargainService ozbargainService, OpenRouterService openRouterService, ConversationService conversationService) {
         this.dealHistoryRepository = dealHistoryRepository;
         this.ozbargainService = ozbargainService;
         this.openRouterService = openRouterService;
+        this.conversationService = conversationService;
     }
 
     @Override
@@ -85,8 +88,14 @@ public class MessageListener extends ListenerAdapter {
                 channel.sendMessage(String.format("I love %s charlie\nI love %s!!!", lovedThing, lovedThing)).queue();
             }
         } else if (message.getMentions().getUsers().contains(griddyBot) && promptMatcher.find()) {
-            channel.retrieveMessageById(message.getId()).queue(msg ->
-                    msg.reply(openRouterService.ask(promptMatcher.group(1))).queue());
+            String prompt = promptMatcher.group(1);
+            String channelId = channel.getId();
+            channel.retrieveMessageById(message.getId()).queue(msg -> {
+                conversationService.addMessage(channelId, "user", prompt);
+                String response = openRouterService.ask(conversationService.getHistory(channelId));
+                conversationService.addMessage(channelId, "assistant", response);
+                msg.reply(response).queue();
+            });
         }
     }
 }

--- a/src/main/java/com/dylansbogar/griddybot/utils/ConversationHistory.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/ConversationHistory.java
@@ -1,0 +1,15 @@
+package com.dylansbogar.griddybot.utils;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConversationHistory {
+    private final List<JSONObject> messages = new ArrayList<>();
+    private String summary;
+
+    public List<JSONObject> getMessages() { return messages; }
+    public String getSummary() { return summary; }
+    public void setSummary(String summary) { this.summary = summary; }
+}

--- a/src/main/java/com/dylansbogar/griddybot/utils/ConversationService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/ConversationService.java
@@ -1,0 +1,84 @@
+package com.dylansbogar.griddybot.utils;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class ConversationService {
+    private static final String SUMMARY_MODEL = "meta-llama/llama-3.2-3b-instruct";
+    private static final String API_URL = "https://openrouter.ai/api/v1/chat/completions";
+    private static final String API_KEY = System.getenv("OPENROUTER_API_KEY");
+
+    private final Map<String, ConversationHistory> histories = new ConcurrentHashMap<>();
+
+    public ConversationHistory getHistory(String channelId) {
+        return histories.computeIfAbsent(channelId, k -> new ConversationHistory());
+    }
+
+    public void addMessage(String channelId, String role, String content) {
+        ConversationHistory history = getHistory(channelId);
+        history.getMessages().add(new JSONObject().put("role", role).put("content", content));
+
+        if (history.getMessages().size() > 20) {
+            List<JSONObject> toSummarize = new ArrayList<>(history.getMessages().subList(0, 20));
+            JSONObject latest = history.getMessages().get(20);
+
+            String newSummary = summarize(toSummarize, history.getSummary());
+            history.setSummary(newSummary);
+            history.getMessages().clear();
+            history.getMessages().add(latest);
+        }
+    }
+
+    private String summarize(List<JSONObject> messages, String existingSummary) {
+        try {
+            StringBuilder conversation = new StringBuilder();
+            if (existingSummary != null && !existingSummary.isEmpty()) {
+                conversation.append("Previous summary: ").append(existingSummary).append("\n\n");
+            }
+            conversation.append("Conversation:\n");
+            for (JSONObject msg : messages) {
+                conversation.append(msg.getString("role")).append(": ")
+                        .append(msg.getString("content")).append("\n");
+            }
+
+            String prompt = "Summarize the following conversation concisely, incorporating any previous summary. Keep it under 500 characters.\n\n"
+                    + conversation;
+
+            JSONObject body = new JSONObject()
+                    .put("model", SUMMARY_MODEL)
+                    .put("messages", new JSONArray()
+                            .put(new JSONObject()
+                                    .put("role", "user")
+                                    .put("content", prompt)));
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(API_URL))
+                    .header("Authorization", "Bearer " + API_KEY)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+                    .build();
+
+            HttpResponse<String> response = HttpClient.newHttpClient()
+                    .send(request, HttpResponse.BodyHandlers.ofString());
+
+            JSONObject json = new JSONObject(response.body());
+            return json.getJSONArray("choices")
+                    .getJSONObject(0)
+                    .getJSONObject("message")
+                    .getString("content");
+        } catch (Exception e) {
+            return existingSummary != null ? existingSummary : "";
+        }
+    }
+}

--- a/src/main/java/com/dylansbogar/griddybot/utils/OpenRouterService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/OpenRouterService.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 
 @Service
 public class OpenRouterService {
@@ -24,13 +25,27 @@ public class OpenRouterService {
         this.googleSearchService = googleSearchService;
     }
 
-    public String ask(String prompt) {
-        String fullPrompt = prompt + " (Please keep your response under 2000 characters)";
+    public String ask(ConversationHistory history) {
         try {
-            JSONArray messages = new JSONArray()
-                    .put(new JSONObject()
+            JSONArray messages = new JSONArray();
+
+            if (history.getSummary() != null && !history.getSummary().isEmpty()) {
+                messages.put(new JSONObject()
+                        .put("role", "system")
+                        .put("content", "Previous conversation context: " + history.getSummary()));
+            }
+
+            List<JSONObject> historyMessages = history.getMessages();
+            for (int i = 0; i < historyMessages.size(); i++) {
+                JSONObject msg = historyMessages.get(i);
+                if (i == historyMessages.size() - 1 && "user".equals(msg.getString("role"))) {
+                    messages.put(new JSONObject()
                             .put("role", "user")
-                            .put("content", fullPrompt));
+                            .put("content", msg.getString("content") + " (Please keep your response under 2000 characters)"));
+                } else {
+                    messages.put(msg);
+                }
+            }
 
             JSONArray tools = new JSONArray()
                     .put(new JSONObject()

--- a/src/main/java/com/dylansbogar/griddybot/utils/OpenRouterService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/OpenRouterService.java
@@ -96,7 +96,7 @@ public class OpenRouterService {
 
             return responseMessage.getString("content");
         } catch (Exception e) {
-            return "Seems I made a fucky wucky, please try again later.";
+            return "Seems I made a fucky wucky, please try again later.\n`" + e.getMessage() + "`";
         }
     }
 


### PR DESCRIPTION
## Summary
- Added `ConversationHistory` to hold per-channel message history and rolling summary
- Added `ConversationService` to manage histories — triggers compaction when the 21st message arrives, summarising the first 20 via `meta-llama/llama-3.2-3b-instruct` and carrying the summary forward
- Updated `OpenRouterService.ask()` to accept a `ConversationHistory`, injecting the summary as a system message and full history as context
- Wired `ConversationService` into `MessageListener` and `BotConfig`

## Notes
- History is in-memory only and resets on restart
- History is per-channel
- The rolling summary is included in each compaction so context compounds over time

## Test plan
- [ ] Mention the bot and verify it responds with context from earlier in the conversation
- [ ] Send 21+ messages and verify compaction triggers without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)