### PR TITLE
AI web search, conversation history, and new commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# Griddybot
+
+A Spring Boot Discord bot using JDA. Runs on a Raspberry Pi.
+
+## Architecture
+
+- **BotConfig** — wires JDA, registers all listeners and slash commands
+- **MessageListener** — handles all incoming messages (not slash commands)
+- Slash commands each have their own listener class under `commands/`
+- Services live under `utils/`
+- Database entities and repositories under `entities/` and `repositories/`
+
+## Environment Variables
+
+All env vars are read as static fields at startup (required for the Pi environment).
+
+| Variable | Used by |
+|---|---|
+| `BOT_TOKEN` | BotConfig |
+| `OPENROUTER_API_KEY` | OpenRouterService, ConversationService |
+| `GOOGLE_API_KEY` | GoogleSearchService |
+| `GOOGLE_SEARCH_ENGINE_ID` | GoogleSearchService |
+| `EXCHANGE_RATE_API_KEY` | YenService |
+| `POSTGRES_USERNAME` / `POSTGRES_PASSWORD` / `DATABASE_NAME` | application.yaml |
+| `CHANNEL_ID` | BotConfig (OzBargain deal posting + reminders) |
+
+## AI (OpenRouter)
+
+- Model defaults to `minimax/minimax-m2.7`, changeable at runtime via `/model`
+- Mention the bot (`@griddybot <prompt>`) to send a prompt
+- Uses tool calling — the model decides when to call `web_search` via the Google Custom Search JSON API (100 free queries/day)
+- Per-channel conversation history is kept in memory (resets on restart)
+- History auto-compacts at 21 messages: the first 20 are summarised by `meta-llama/llama-3.2-3b-instruct` and stored as a rolling summary injected as a system message on every request
+
+## Message Triggers (MessageListener)
+
+| Trigger | Response |
+|---|---|
+| Message starts with `https://www.ozbargain.com.au/node/` | Repost check + embed |
+| `gm` / `gn` | Echoes back |
+| `thanks griddy` | "No worries <3" |
+| `i love <x>` | "I love x charlie / I love x!!!" |
+| `@griddybot <prompt>` | AI response via OpenRouter |
+
+## Slash Commands
+
+| Command | Description |
+|---|---|
+| `/coinflip` | Heads or tails |
+| `/daylist <daylist>` | Log a Spotify daylist and track mood |
+| `/undodaylist` | Remove most recent daylist entry |
+| `/emote <name>` | Retrieve a 7TV emote |
+| `/minecraft <server>` | Get status of a Minecraft server |
+| `/yen` | AUD → JPY conversion rate |
+| `/remindme <date> <message>` | Set a reminder (checked daily at 9am) |
+| `/model <model_id>` | Switch the OpenRouter model at runtime |
+
+## Database (PostgreSQL)
+
+Used for: daylists, daylist descriptions, emotes, exchange rates, reminders, OzBargain deal history (repost detection).

--- a/src/main/java/com/dylansbogar/griddybot/BotConfig.java
+++ b/src/main/java/com/dylansbogar/griddybot/BotConfig.java
@@ -41,6 +41,7 @@ public class BotConfig {
     private final ReminderRepository reminderRepo;
     private final OzbargainService ozbargainService;
     private final DealHistoryRepository dealHistoryRepo;
+    private final LastServerRepository lastServerRepo;
     private final OpenRouterService openRouterService;
     private final ConversationService conversationService;
 
@@ -60,6 +61,7 @@ public class BotConfig {
         api.addEventListener(
                 new MessageListener(dealHistoryRepo, ozbargainService, openRouterService, conversationService),
                 new ModelCommand(openRouterService),
+                new LastServerCommand(lastServerRepo),
                 new CoinflipCommand(),
                 new DaylistCommand(daylistRepo, daylistDescriptionRepo),
                 new EmoteCommand(emoteRepo),
@@ -83,7 +85,11 @@ public class BotConfig {
                         .addOption(OptionType.STRING, "date", "The date you wish to be reminded, in dd/mm/yyyy format.", true)
                         .addOption(OptionType.STRING, "message", "The message you wish to remind yourself.", true),
                 Commands.slash("model", "Set the AI model used by the bot.")
-                        .addOption(OptionType.STRING, "model_id", "The OpenRouter model ID (e.g. minimax/minimax-m2.7).", true)
+                        .addOption(OptionType.STRING, "model_id", "The OpenRouter model ID (e.g. minimax/minimax-m2.7).", true),
+                Commands.slash("setlastserver", "Set the date and description of the last server.")
+                        .addOption(OptionType.STRING, "date", "The date in DD/MM/YY format.", true)
+                        .addOption(OptionType.STRING, "description", "Description of the server.", true),
+                Commands.slash("lastserver", "See how many days it's been since the last server.")
         ).queue();
 
         return api;

--- a/src/main/java/com/dylansbogar/griddybot/BotConfig.java
+++ b/src/main/java/com/dylansbogar/griddybot/BotConfig.java
@@ -62,6 +62,7 @@ public class BotConfig {
                 new MessageListener(dealHistoryRepo, ozbargainService, openRouterService, conversationService),
                 new ModelCommand(openRouterService),
                 new LastServerCommand(lastServerRepo),
+                new HistoryCommand(conversationService),
                 new CoinflipCommand(),
                 new DaylistCommand(daylistRepo, daylistDescriptionRepo),
                 new EmoteCommand(emoteRepo),
@@ -89,7 +90,8 @@ public class BotConfig {
                 Commands.slash("setlastserver", "Set the date and description of the last server.")
                         .addOption(OptionType.STRING, "date", "The date in DD/MM/YY format.", true)
                         .addOption(OptionType.STRING, "description", "Description of the server.", true),
-                Commands.slash("lastserver", "See how many days it's been since the last server.")
+                Commands.slash("lastserver", "See how many days it's been since the last server."),
+                Commands.slash("history", "Show the AI conversation summary for this channel.")
         ).queue();
 
         return api;

--- a/src/main/java/com/dylansbogar/griddybot/commands/HistoryCommand.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/HistoryCommand.java
@@ -1,0 +1,28 @@
+package com.dylansbogar.griddybot.commands;
+
+import com.dylansbogar.griddybot.utils.ConversationHistory;
+import com.dylansbogar.griddybot.utils.ConversationService;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class HistoryCommand extends ListenerAdapter {
+    private final ConversationService conversationService;
+
+    public HistoryCommand(ConversationService conversationService) {
+        this.conversationService = conversationService;
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!event.getName().equals("history")) return;
+
+        ConversationHistory history = conversationService.getHistory(event.getChannel().getId());
+        String summary = history.getSummary();
+
+        if (summary == null || summary.isEmpty()) {
+            event.reply("No summary yet — conversation hasn't been compacted.").setEphemeral(true).queue();
+        } else {
+            event.reply("**Conversation summary:**\n" + summary).setEphemeral(true).queue();
+        }
+    }
+}

--- a/src/main/java/com/dylansbogar/griddybot/commands/LastServerCommand.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/LastServerCommand.java
@@ -1,0 +1,60 @@
+package com.dylansbogar.griddybot.commands;
+
+import com.dylansbogar.griddybot.entities.LastServer;
+import com.dylansbogar.griddybot.repositories.LastServerRepository;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+public class LastServerCommand extends ListenerAdapter {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yy");
+    private static final long RECORD_ID = 1L;
+
+    private final LastServerRepository lastServerRepository;
+
+    public LastServerCommand(LastServerRepository lastServerRepository) {
+        this.lastServerRepository = lastServerRepository;
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (event.getName().equals("setlastserver")) {
+            String date = event.getOption("date").getAsString();
+            String description = event.getOption("description").getAsString();
+
+            try {
+                LocalDate.parse(date, FORMATTER);
+            } catch (DateTimeParseException e) {
+                event.reply("Invalid date format. Please use DD/MM/YY.").setEphemeral(true).queue();
+                return;
+            }
+
+            lastServerRepository.save(LastServer.builder()
+                    .id(RECORD_ID)
+                    .date(date)
+                    .description(description)
+                    .build());
+
+            event.reply("Last server set to **" + date + "** — " + description).queue();
+
+        } else if (event.getName().equals("lastserver")) {
+            Optional<LastServer> record = lastServerRepository.findById(RECORD_ID);
+
+            if (record.isEmpty()) {
+                event.reply("No last server has been set yet. Use `/setlastserver` to set one.").queue();
+                return;
+            }
+
+            LastServer lastServer = record.get();
+            LocalDate past = LocalDate.parse(lastServer.getDate(), FORMATTER);
+            long days = ChronoUnit.DAYS.between(past, LocalDate.now());
+
+            event.reply("It has been **" + days + " day" + (days == 1 ? "" : "s") + "** since " + lastServer.getDescription()).queue();
+        }
+    }
+}

--- a/src/main/java/com/dylansbogar/griddybot/entities/LastServer.java
+++ b/src/main/java/com/dylansbogar/griddybot/entities/LastServer.java
@@ -1,0 +1,22 @@
+package com.dylansbogar.griddybot.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "last_server")
+public class LastServer {
+    @Id
+    private Long id;
+
+    private String date;
+
+    private String description;
+}

--- a/src/main/java/com/dylansbogar/griddybot/repositories/LastServerRepository.java
+++ b/src/main/java/com/dylansbogar/griddybot/repositories/LastServerRepository.java
@@ -1,0 +1,9 @@
+package com.dylansbogar.griddybot.repositories;
+
+import com.dylansbogar.griddybot.entities.LastServer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LastServerRepository extends JpaRepository<LastServer, Long> {
+}

--- a/src/main/java/com/dylansbogar/griddybot/utils/OpenRouterService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/OpenRouterService.java
@@ -88,16 +88,23 @@ public class OpenRouterService {
                 }
 
                 JSONObject finalResponse = callApi(messages, null);
-                return finalResponse.getJSONArray("choices")
+                return extractContent(finalResponse.getJSONArray("choices")
                         .getJSONObject(0)
-                        .getJSONObject("message")
-                        .getString("content");
+                        .getJSONObject("message"));
             }
 
-            return responseMessage.getString("content");
+            return extractContent(responseMessage);
         } catch (Exception e) {
             return "Seems I made a fucky wucky, please try again later.\n`" + e.getMessage() + "`";
         }
+    }
+
+    private String extractContent(JSONObject message) {
+        String content = message.optString("content", null);
+        if (content == null) {
+            throw new RuntimeException("null content in response: " + message);
+        }
+        return content;
     }
 
     private JSONObject callApi(JSONArray messages, JSONArray tools) throws Exception {


### PR DESCRIPTION
- **Error surfacing** — OpenRouter errors and null content responses are shown in the Discord reply
- **`/history`** — shows the compacted conversation summary for the current channel (ephemeral)
- **`/setlastserver <date> <description>`** — stores a date + description in the DB
- **`/lastserver`** — replies with how many days have passed since the stored date
- **CLAUDE.md** — documents how the bot works

## Setup
- Set `OPENROUTER_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID` in your environment
- Create a Programmable Search Engine at programmablesearchengine.google.com set to search the entire web

## Test plan
- [ ] Mention the bot and verify it responds with context from earlier messages
- [ ] Ask a question requiring current info and verify it searches
- [ ] Send 21+ messages and verify compaction runs without errors
- [ ] Run `/history` and verify the summary appears
- [ ] Run `/setlastserver` and `/lastserver` and verify the day count is correct
- [ ] Run `/model` to switch models and verify subsequent responses use the new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)