### PR TITLE
Fix :duc: emoji ID in bully messages

### DIFF
--- a/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
@@ -67,7 +67,7 @@ public class MessageListener extends ListenerAdapter {
 
         if (instagramMatcher.find()) {
             if(bullyList.contains(event.getAuthor())) {
-                channel.sendMessage("Owops, sowwy, I dont hewp buwwies >:( . Undew you want to add me to hades-homosexuaws? :duc:").queue();
+                channel.sendMessage("Owops, sowwy, I dont hewp buwwies >:( . Undew you want to add me to hades-homosexuaws? <:duc:1082878057444036678>").queue();
                 return;
             }
 
@@ -131,7 +131,7 @@ public class MessageListener extends ListenerAdapter {
             channel.sendMessage("https://tenor.com/view/staring-press-close-staredown-train-gif-22975756").queue();
         } else if (message.getMentions().getUsers().contains(griddyBot) && promptMatcher.find()) {
             if(bullyList.contains(event.getAuthor())) {
-                channel.sendMessage("Owops, sowwy, I dont hewp buwwies >:( . Undew you want to add me to hades-homosexuaws? :duc:").queue();
+                channel.sendMessage("Owops, sowwy, I dont hewp buwwies >:( . Undew you want to add me to hades-homosexuaws? <:duc:1082878057444036678>").queue();
                 return;
             }
             String prompt = promptMatcher.group(1);


### PR DESCRIPTION
## Summary
- Replace `:duc:` with `<:duc:1082878057444036678>` in both bully-list response messages in `MessageListener.java`
- `:duc:` is not a valid Discord emoji reference — custom emojis must use the `<:name:id>` format to render correctly

## Test plan
- [ ] Trigger a bully-list message (Instagram link or bot mention while on the bully list) and confirm the duc emoji renders instead of showing as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)