### PR TITLE
Add social credit system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ build/
 
 ### Stored Emotes ###
 **/src/main/resources/emotes/*
+
+### Claude (plan files, local settings) ###
+.claude/

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ reaction type on each top-reacted message (short-circuited on first match).
 fine for a once-a-week job.
 
 - "Reactions" means effective Discord reactions: total count **minus**
-  Griddybot's own reactions (`MessageReaction.isSelf()`). This stops the
+  Griddy's own reactions (`MessageReaction.isSelf()`). This stops the
   bot's bully-reactions from looking like popularity.
 - 7TV / BetterTTV inline emotes are NOT reactions and don't count.
 - Top-reacted messages are always promoted to highlights, guaranteeing the

--- a/README.md
+++ b/README.md
@@ -1,1 +1,179 @@
 # griddybot
+
+## Social Credit System
+
+A weekly bot job that evaluates each user's Discord activity in `CHANNEL_ID`
+over the past 7 days and assigns/removes "social credit" points based on what
+an LLM thinks of their messages. Every Monday at 9am the bot posts a recap
+embed to the channel showing each active user's updated total, the weekly
+delta, and a one-sentence reason.
+
+- Messages are **not** logged in real time — on Monday morning the bot fetches
+  the week's history straight from Discord via JDA's `getIterableHistory()`.
+- One LLM call per active user per week + one "newspaper editor" call that
+  writes the recap article (cheap — fractions of a cent).
+- Running totals live in the `social_credit` Postgres table.
+- A `/leaderboard` slash command shows the current standings on demand.
+
+### Who gets evaluated
+
+Only the 5 regulars listed in
+[`UserConstants.REGULAR_USER_IDS`](src/main/java/com/dylansbogar/griddybot/utils/UserConstants.java)
+are tracked: Matt, Dylan, Duc, Brodey, Dean. Messages from anyone else
+(guests, lurkers, ex-members) are ignored entirely.
+
+**Alt accounts** (declared in `UserConstants.ACCOUNT_ALIASES`) are
+attributed to the canonical user. Messages from Matt's alt account are
+merged into Matt's weekly evaluation, count toward his activity, and roll
+into his single scoreline. The alt never appears as its own row in the
+leaderboard or article.
+
+To target a specific person in a future feature, reference them by name from
+`UserConstants` (e.g. `UserConstants.DUC_ID`) rather than hardcoding the
+snowflake.
+
+### Inactivity tracking
+
+Regulars who barely participate get a small penalty, intended as a playful
+call-out for "not being part of the fun." Computed each week:
+
+- **Median** message count is calculated across regulars who posted at least
+  once. Median (not mean) so one mega-poster doesn't drag the bar up.
+- **Quiet** (`-10`): posted less than 30% of the median. Gets a normal LLM
+  evaluation **plus** the penalty, and the editor is told they were quiet.
+- **Absent** (`-20`): posted nothing at all. Gets a synthetic
+  "WHERE WAS DUC?" headline in the article.
+- **Activity floor**: nobody is flagged unless the median is at least 50
+  messages. Avoids punishing genuinely slow weeks for the whole group.
+
+Inactivity is checked in **production runs only**. Debug runs skip it (the
+friend testing in a private channel doesn't have the production roster
+posting there, so every regular would be marked absent every run).
+
+### Reaction tracking
+
+Discord reactions on a user's messages are tiered and surfaced to the LLM so
+genuinely popular moments earn rewards and headlines. The LLM does all the
+scoring — there's no deterministic bonus — so a cruel viral message won't be
+rewarded just because it was popular.
+
+| Tier          | Threshold | What it means                                                       |
+|---------------|-----------|---------------------------------------------------------------------|
+| `GOOD`        | 3+        | Modest popularity — small positive nudge + brief highlight          |
+| `BETTER`      | 4+        | Notably popular — meaningful weight + dedicated highlight           |
+| `LEGENDARY`   | 5+        | Major moment — strong positive delta + top-billed headline          |
+| `SELF-REACT`  | Any tier  | Author reacted to their own message — cringe, overrides all tiers   |
+
+The `SELF-REACT` override fires whenever the author appears in their own
+message's reaction user list. Discord doesn't bundle reaction users with the
+initial message fetch, so detecting this requires one extra REST call per
+reaction type on each top-reacted message (short-circuited on first match).
+~30–100 extra REST calls per weekly run, a few seconds of added latency —
+fine for a once-a-week job.
+
+- "Reactions" means effective Discord reactions: total count **minus**
+  Griddybot's own reactions (`MessageReaction.isSelf()`). This stops the
+  bot's bully-reactions from looking like popularity.
+- 7TV / BetterTTV inline emotes are NOT reactions and don't count.
+- Top-reacted messages are always promoted to highlights, guaranteeing the
+  editor writes about them in the newspaper article.
+
+#### Server emoji glossary
+
+The friend group's custom server emojis are registered in
+[`ServerEmoji`](src/main/java/com/dylansbogar/griddybot/utils/ServerEmoji.java)
+with short descriptions of how each is actually used (e.g. `:OMEGALUL:` =
+genuinely funny vs `:LAUGH:` = sarcastic/dismissive). When a user's
+top-reacted messages contain any of these emojis, an **EMOJI GLOSSARY**
+block is prepended to the per-user prompt so the LLM can interpret 5
+`:OMEGALUL:` reactions as "very funny" instead of just "five reactions of
+something". Add new server emojis as enum entries.
+
+### Testing in a private server
+
+All knobs live at the top of
+[`SocialCreditDebug.java`](src/main/java/com/dylansbogar/griddybot/utils/SocialCreditDebug.java):
+
+| Constant             | Default           | What it does                                                       |
+| -------------------- | ----------------- | ------------------------------------------------------------------ |
+| `DEBUG_MODE`         | `true`            | Disables the Monday cron and enables the short-interval debug cron |
+| `DEBUG_CRON`         | `"0 */2 * * * *"` | Fires the evaluation every 2 minutes while debug is on             |
+| `DEBUG_WINDOW_HOURS` | `1`               | Looks back only the past hour instead of 7 days                    |
+
+You'll also need to point `CHANNEL_ID` (env var) at your private test channel.
+
+#### Steps
+
+1. Confirm `DEBUG_MODE = true` in `SocialCreditDebug.java`.
+2. Set `CHANNEL_ID` to your test channel's ID, plus the usual env vars
+   (`BOT_TOKEN`, `OPENROUTER_API_KEY`, Postgres credentials).
+3. Rebuild: `./mvnw clean package`.
+4. Run the bot.
+5. Post some messages in the test channel.
+6. Within 2 minutes the bot will:
+   - Post a `[DEBUG] Weekly Social Credit Report...` embed to the channel.
+   - Print `[social-credit-debug]` summary lines to stdout.
+   - Write one row per evaluated user to the `social_credit_debug_log` table.
+
+#### Where to look for logs
+
+**Stdout** — high-level run progress:
+
+```
+[social-credit-debug] Social credit run starting at 2026-05-21T07:30:00Z (window cutoff: 2026-05-21T06:30:00Z)
+[social-credit-debug] Fetched 42 messages from channel
+[social-credit-debug] Active users this window: 3
+[social-credit-debug]   alice#0: delta=+12, newTotal=12
+[social-credit-debug]   bob#0: delta=-3, newTotal=-3
+[social-credit-debug]   matt#0: delta=-25, newTotal=-25
+[social-credit-debug] Social credit run finished at 2026-05-21T07:30:04Z
+```
+
+**Postgres** — full per-user evaluation details (gathered messages, full
+prompt, raw LLM response, parsed delta/reasoning, any error):
+
+```sql
+SELECT run_at, user_tag, stern_bias, message_count,
+       parsed_delta, parsed_reasoning, error
+FROM social_credit_debug_log
+ORDER BY run_at DESC;
+```
+
+For deeper digging (the full prompt or raw model output):
+
+```sql
+SELECT prompt, llm_response
+FROM social_credit_debug_log
+WHERE user_tag = 'matt#0'
+ORDER BY run_at DESC
+LIMIT 1;
+```
+
+The newspaper editor pass (the second LLM call that writes the recap article)
+is logged under `user_id = '__editor__'`:
+
+```sql
+SELECT prompt, llm_response, error
+FROM social_credit_debug_log
+WHERE user_id = '__editor__'
+ORDER BY run_at DESC
+LIMIT 1;
+```
+
+**Running totals** — the actual score table (updated by both debug and prod
+runs):
+
+```sql
+SELECT user_tag, total_points, last_week_delta, last_week_reason, last_evaluated_at
+FROM social_credit
+ORDER BY total_points DESC;
+```
+
+#### Switching off debug
+
+When you're happy with the behaviour:
+
+1. Set `DEBUG_MODE = false` in `SocialCreditDebug.java`.
+2. Rebuild and redeploy.
+3. The Monday 9am cron takes over. The `social_credit_debug_log` table stops
+   receiving new rows; you can drop or truncate it any time.

--- a/src/main/java/com/dylansbogar/griddybot/BotConfig.java
+++ b/src/main/java/com/dylansbogar/griddybot/BotConfig.java
@@ -2,6 +2,7 @@ package com.dylansbogar.griddybot;
 
 import com.dylansbogar.griddybot.commands.*;
 import com.dylansbogar.griddybot.entities.Reminder;
+import com.dylansbogar.griddybot.entities.SocialCredit;
 import com.dylansbogar.griddybot.repositories.*;
 import com.dylansbogar.griddybot.utils.*;
 import com.dylansbogar.griddybot.utils.ozbargain.Deal;
@@ -12,18 +13,23 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.GatewayIntent;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Configuration
 @RequiredArgsConstructor
@@ -135,6 +141,49 @@ public class BotConfig {
     public void runSocialCreditWeekly() {
         if (SocialCreditDebug.DEBUG_MODE) return;
         runSocialCredit(false);
+    }
+
+    // Spring's @Scheduled does NOT replay a cron firing that was missed while
+    // the app was down — and a Pi reboots. If the bot is offline at 9am Monday,
+    // that week would otherwise never be scored, and the gap falls permanently
+    // out of the next run's 7-day window. On startup we check the most recent
+    // successful evaluation: if it's more than 7 days old, at least one Monday
+    // was missed, so we run the weekly evaluation once to catch up. A fresh
+    // install (no prior run) is left alone — there is nothing to recover, so we
+    // just wait for the first Monday.
+    @EventListener(ApplicationReadyEvent.class)
+    public void catchUpSocialCreditOnStartup() {
+        if (SocialCreditDebug.DEBUG_MODE || api == null) return;
+        // JDA logs in asynchronously; wait for it on a daemon thread so a bad
+        // token (which would never become ready) can't hang app startup.
+        Thread t = new Thread(() -> {
+            try {
+                api.awaitReady();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            Instant lastRun = socialCreditRepo.findAll().stream()
+                    .map(SocialCredit::getLastEvaluatedAt)
+                    .filter(Objects::nonNull)
+                    .max(Comparator.naturalOrder())
+                    .orElse(null);
+            if (lastRun == null) {
+                System.out.println("Social credit: no prior evaluation on record; "
+                        + "skipping startup catch-up (waiting for the next Monday).");
+                return;
+            }
+            if (lastRun.isAfter(Instant.now().minus(7, ChronoUnit.DAYS))) {
+                System.out.println("Social credit: last evaluation " + lastRun
+                        + " is within 7 days; no catch-up needed.");
+                return;
+            }
+            System.out.println("Social credit: last evaluation " + lastRun
+                    + " is over 7 days ago — a weekly run was missed. Catching up now.");
+            runSocialCredit(false);
+        }, "social-credit-catchup");
+        t.setDaemon(true);
+        t.start();
     }
 
     @Scheduled(cron = SocialCreditDebug.DEBUG_CRON)

--- a/src/main/java/com/dylansbogar/griddybot/BotConfig.java
+++ b/src/main/java/com/dylansbogar/griddybot/BotConfig.java
@@ -46,6 +46,10 @@ public class BotConfig {
     private final ConversationService conversationService;
     private final InstagramService instagramService;
     private final ReactionService reactionService;
+    private final SocialCreditService socialCreditService;
+    private final SocialCreditRepository socialCreditRepo;
+
+    private final EmbedGenerator embedGenerator = new EmbedGenerator();
 
     private JDA api;
 
@@ -71,7 +75,8 @@ public class BotConfig {
                 new EmoteCommand(emoteRepo),
                 new MinecraftCommand(),
                 new YenCommand(yenService),
-                new RemindMeCommand(reminderRepo));
+                new RemindMeCommand(reminderRepo),
+                new LeaderboardCommand(socialCreditRepo));
 
         // The text-content of each slash command, which shows to the user upon typing.
         api.updateCommands().addCommands(
@@ -94,7 +99,8 @@ public class BotConfig {
                         .addOption(OptionType.STRING, "date", "The date in DD/MM/YY format.", true)
                         .addOption(OptionType.STRING, "description", "Description of the server.", true),
                 Commands.slash("lastserver", "See how many days it's been since the last server."),
-                Commands.slash("history", "Show the AI conversation summary for this channel.")
+                Commands.slash("history", "Show the AI conversation summary for this channel."),
+                Commands.slash("leaderboard", "Show the social credit leaderboard.")
         ).queue();
 
         return api;
@@ -123,6 +129,30 @@ public class BotConfig {
                 }
             }
         }
+    }
+
+    @Scheduled(cron = "0 0 9 * * MON")
+    public void runSocialCreditWeekly() {
+        if (SocialCreditDebug.DEBUG_MODE) return;
+        runSocialCredit(false);
+    }
+
+    @Scheduled(cron = SocialCreditDebug.DEBUG_CRON)
+    public void runSocialCreditDebug() {
+        if (!SocialCreditDebug.DEBUG_MODE) return;
+        runSocialCredit(true);
+    }
+
+    private void runSocialCredit(boolean debug) {
+        if (api == null) return;
+        MessageChannel channel = api.getTextChannelById(CHANNEL_ID);
+        if (channel == null) {
+            System.out.println("Social credit: channel " + CHANNEL_ID + " not found");
+            return;
+        }
+        System.out.println("Running social credit evaluation (debug=" + debug + ")...");
+        SocialCreditService.WeeklyReport report = socialCreditService.evaluateWeek(channel);
+        channel.sendMessageEmbeds(embedGenerator.buildSocialCreditEmbed(report, debug).build()).queue();
     }
 
     @Scheduled(cron = "0 */5 * * * *")

--- a/src/main/java/com/dylansbogar/griddybot/commands/LeaderboardCommand.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/LeaderboardCommand.java
@@ -1,0 +1,50 @@
+package com.dylansbogar.griddybot.commands;
+
+import com.dylansbogar.griddybot.entities.SocialCredit;
+import com.dylansbogar.griddybot.repositories.SocialCreditRepository;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.util.List;
+
+public class LeaderboardCommand extends ListenerAdapter {
+    private final SocialCreditRepository creditRepo;
+
+    public LeaderboardCommand(SocialCreditRepository creditRepo) {
+        this.creditRepo = creditRepo;
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!event.getName().equals("leaderboard")) return;
+
+        event.deferReply().queue();
+
+        List<SocialCredit> rows = creditRepo.findAllByOrderByTotalPointsDesc();
+
+        EmbedBuilder embed = new EmbedBuilder();
+        embed.setTitle(":trophy: Social Credit Leaderboard");
+
+        if (rows.isEmpty()) {
+            embed.setDescription("No one has been evaluated yet. Check back after Monday.");
+            event.getHook().sendMessageEmbeds(embed.build()).queue();
+            return;
+        }
+
+        String[] medals = {":first_place:", ":second_place:", ":third_place:"};
+        StringBuilder body = new StringBuilder();
+        for (int i = 0; i < rows.size(); i++) {
+            SocialCredit r = rows.get(i);
+            String medal = i < medals.length ? medals[i] + " " : "   ";
+            String deltaNote = r.getLastWeekDelta() == 0
+                    ? ""
+                    : String.format("  _(last week %+d)_", r.getLastWeekDelta());
+            body.append(String.format("%s**%s** — %,d pts%s%n",
+                    medal, r.getUserTag(), r.getTotalPoints(), deltaNote));
+        }
+        embed.setDescription(body.toString());
+
+        event.getHook().sendMessageEmbeds(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
@@ -4,6 +4,7 @@ import com.dylansbogar.griddybot.entities.PostedDeal;
 import com.dylansbogar.griddybot.repositories.DealHistoryRepository;
 import com.dylansbogar.griddybot.utils.*;
 import net.dv8tion.jda.api.entities.*;
+import static com.dylansbogar.griddybot.utils.UserConstants.BULLY_IDS;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -23,7 +24,6 @@ public class MessageListener extends ListenerAdapter {
             "https?://(?:www\\.)?instagram\\.com/reel/[A-Za-z0-9_-]+/?(?:\\?[^\\s]*)?",
             Pattern.CASE_INSENSITIVE
     );
-    private static final List<UserSnowflake> bullyList = List.of(User.fromId("187817424337240064"), User.fromId("1265821669985878208"));
     private static final List<String> ANNOYING_QUESTIONS = List.of("hey %s, how are you?", "hey %s, quick question",
             "hey %s, you free?", "hi %s, how was your weekend?");
 
@@ -73,7 +73,7 @@ public class MessageListener extends ListenerAdapter {
         Pattern promptPattern = Pattern.compile("<@!?" + griddyBot.getId() + ">\\s*(.*)");
         Matcher promptMatcher = promptPattern.matcher(event.getMessage().getContentRaw());
 
-        if(bullyList.contains(event.getAuthor())) {
+        if(BULLY_IDS.contains(event.getAuthor().getId())) {
             if(!blockingQuestion.isEmpty()) {
                 Message referencedMessage = message.getReferencedMessage();
                 if(message.getType().equals(MessageType.INLINE_REPLY) && blockingQuestion.contains(referencedMessage)) {
@@ -107,7 +107,7 @@ public class MessageListener extends ListenerAdapter {
         }
 
         if (instagramMatcher.find()) {
-            if(bullyList.contains(event.getAuthor())) {
+            if(BULLY_IDS.contains(event.getAuthor().getId())) {
                 channel.sendMessage("Owops, sowwy, I dont hewp buwwies >:( . Undew you want to add me to hades-homosexuaws? <:duc:1082878057444036678>").queue();
                 return;
             }
@@ -140,7 +140,7 @@ public class MessageListener extends ListenerAdapter {
                 }
             }
         } else if (content.equalsIgnoreCase("gm") || content.equalsIgnoreCase("gn")) {
-            if(bullyList.contains(event.getAuthor())) {
+            if(BULLY_IDS.contains(event.getAuthor().getId())) {
                 if(content.equalsIgnoreCase("gm")) {
                     channel.sendMessage("Bad morning >:(").queue();
                 } else {
@@ -150,13 +150,13 @@ public class MessageListener extends ListenerAdapter {
             }
             channel.sendMessage(content).queue();
         } else if (thanks.find()) {
-            if(bullyList.contains(event.getAuthor())) {
+            if(BULLY_IDS.contains(event.getAuthor().getId())) {
                 channel.sendMessage("...").queue();
             } else {
                 channel.sendMessage("No worries <3").queue();
             }
         } else if (love.find()) {
-            if(bullyList.contains(event.getAuthor())) {
+            if(BULLY_IDS.contains(event.getAuthor().getId())) {
                 channel.sendMessage("yikes, I dont love anything you do >:(").queue();
             } else {
                 String lovedThing = love.group(1);
@@ -171,7 +171,7 @@ public class MessageListener extends ListenerAdapter {
         } else if(cleaned.matches("(?:76)|(?:\\b(?:7|seven)\\b.*\\b(?:6|six)\\b)")) {
 	    channel.sendMessage("https://tenor.com/view/staring-press-close-staredown-train-gif-22975756").queue();
         } else if (message.getMentions().getUsers().contains(griddyBot) && promptMatcher.find()) {
-            if(bullyList.contains(event.getAuthor())) {
+            if(BULLY_IDS.contains(event.getAuthor().getId())) {
                 channel.sendMessage("Owops, sowwy, I dont hewp buwwies >:( . Undew you want to add me to hades-homosexuaws? <:duc:1082878057444036678>").queue();
                 return;
             }
@@ -190,7 +190,7 @@ public class MessageListener extends ListenerAdapter {
                 return; // Should be impossible
             }
 
-            if(bullyList.contains(referencedMessage.getAuthor())) {
+            if(BULLY_IDS.contains(referencedMessage.getAuthor().getId())) {
                 heldMessages.add(message);
                 message.delete().queue();
 

--- a/src/main/java/com/dylansbogar/griddybot/entities/SocialCredit.java
+++ b/src/main/java/com/dylansbogar/griddybot/entities/SocialCredit.java
@@ -1,0 +1,29 @@
+package com.dylansbogar.griddybot.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "social_credit")
+public class SocialCredit {
+    @Id
+    private String userId;
+
+    private String userTag;
+
+    private int totalPoints;
+
+    private int lastWeekDelta;
+
+    @Column(columnDefinition = "TEXT")
+    private String lastWeekReason;
+
+    private Instant lastEvaluatedAt;
+}

--- a/src/main/java/com/dylansbogar/griddybot/entities/SocialCreditDebugLog.java
+++ b/src/main/java/com/dylansbogar/griddybot/entities/SocialCreditDebugLog.java
@@ -1,0 +1,49 @@
+package com.dylansbogar.griddybot.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "social_credit_debug_log")
+public class SocialCreditDebugLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private Instant runAt;
+
+    private String userId;
+
+    private String userTag;
+
+    private boolean sternBias;
+
+    private int messageCount;
+
+    @Column(columnDefinition = "TEXT")
+    private String gatheredMessages;
+
+    @Column(columnDefinition = "TEXT")
+    private String prompt;
+
+    @Column(columnDefinition = "TEXT")
+    private String llmResponse;
+
+    private Integer parsedDelta;
+
+    @Column(columnDefinition = "TEXT")
+    private String parsedReasoning;
+
+    @Column(columnDefinition = "TEXT")
+    private String error;
+}

--- a/src/main/java/com/dylansbogar/griddybot/entities/SocialCreditDebugLog.java
+++ b/src/main/java/com/dylansbogar/griddybot/entities/SocialCreditDebugLog.java
@@ -46,4 +46,20 @@ public class SocialCreditDebugLog {
 
     @Column(columnDefinition = "TEXT")
     private String error;
+
+    // ---- Run-level stats (eval row only; null on per-user rows) ----
+    // Spot cap pressure here: if fetchedCount/trackedCount regularly sit at or
+    // above MAX_MESSAGES_TOTAL (capApplied = true), the weekly conversation is
+    // being truncated and the cap should be raised.
+    private Integer fetchedCount;   // raw messages fetched from Discord (pre-filter)
+    private Integer trackedCount;   // after filtering to tracked authors (pre-cap)
+    private Boolean capApplied;     // trackedCount exceeded MAX_MESSAGES_TOTAL
+
+    // ---- Per-user delta breakdown (per-user rows only; null on the eval row) ----
+    // rawDelta  = the model's delta after clamping.
+    // parsedDelta = the final delta actually applied (after inactivity adjustments).
+    // A gap between the two explains "why fewer points than expected".
+    // newTotal  = the running total after this week's delta was applied.
+    private Integer rawDelta;
+    private Integer newTotal;
 }

--- a/src/main/java/com/dylansbogar/griddybot/repositories/SocialCreditDebugLogRepository.java
+++ b/src/main/java/com/dylansbogar/griddybot/repositories/SocialCreditDebugLogRepository.java
@@ -1,0 +1,11 @@
+package com.dylansbogar.griddybot.repositories;
+
+import com.dylansbogar.griddybot.entities.SocialCreditDebugLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface SocialCreditDebugLogRepository extends JpaRepository<SocialCreditDebugLog, UUID> {
+}

--- a/src/main/java/com/dylansbogar/griddybot/repositories/SocialCreditRepository.java
+++ b/src/main/java/com/dylansbogar/griddybot/repositories/SocialCreditRepository.java
@@ -1,0 +1,12 @@
+package com.dylansbogar.griddybot.repositories;
+
+import com.dylansbogar.griddybot.entities.SocialCredit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SocialCreditRepository extends JpaRepository<SocialCredit, String> {
+    List<SocialCredit> findAllByOrderByTotalPointsDesc();
+}

--- a/src/main/java/com/dylansbogar/griddybot/utils/EmbedGenerator.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/EmbedGenerator.java
@@ -21,7 +21,7 @@ public class EmbedGenerator {
         EmbedBuilder embed = new EmbedBuilder();
         embed.setTitle(title);
         embed.setThumbnail(thumbnailURL);
-        embed.setAuthor("Griddybot", GRIDDY_ICON_URL);
+        embed.setAuthor("Griddy", GRIDDY_ICON_URL);
         embed.setDescription(description);
 
         for (MessageEmbed.Field field: fields) {
@@ -33,15 +33,15 @@ public class EmbedGenerator {
 
     public EmbedBuilder buildSocialCreditEmbed(WeeklyReport report, boolean debug) {
         EmbedBuilder embed = new EmbedBuilder();
-        embed.setAuthor("Griddybot", null, GRIDDY_ICON_URL);
+        embed.setAuthor("Griddy", null, GRIDDY_ICON_URL);
         String prefix = debug ? "[DEBUG] " : "";
-        embed.setTitle(prefix + ":newspaper: The Griddybot Gazette — "
+        embed.setTitle(prefix + ":newspaper: The Griddy Gazette — "
                 + LocalDate.now().format(DateTimeFormatter.ofPattern("d MMM yyyy")));
 
         String standings = buildStandingsSection(report.standings());
 
         if (report.article() == null || report.article().isBlank()) {
-            String quietMsg = "_All quiet on the Griddybot front this week. No new activity to report._";
+            String quietMsg = "_All quiet on the Griddy front this week. No new activity to report._";
             embed.setDescription(quietMsg + "\n\n" + standings);
             return embed;
         }

--- a/src/main/java/com/dylansbogar/griddybot/utils/EmbedGenerator.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/EmbedGenerator.java
@@ -1,13 +1,20 @@
 package com.dylansbogar.griddybot.utils;
 
+import com.dylansbogar.griddybot.entities.SocialCredit;
+import com.dylansbogar.griddybot.utils.SocialCreditService.WeeklyReport;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class EmbedGenerator {
     private static final String GRIDDY_ICON_URL =
             "https://cdn-0.skin-tracker.com/images/fnskins/icon/fortnite-get-griddy-emote.png?ezimgfmt=rs:180x180/rscb10/ngcb10/notWebP";
+
+    private static final int EMBED_DESC_LIMIT = 4096;
+    private static final String TRUNCATION_NOTE = "\n\n_…(article truncated for length)_\n";
 
     public EmbedBuilder generateEmbed(String title, String description, String thumbnailURL,
                                       List<MessageEmbed.Field> fields) {
@@ -22,5 +29,53 @@ public class EmbedGenerator {
         }
 
         return embed;
+    }
+
+    public EmbedBuilder buildSocialCreditEmbed(WeeklyReport report, boolean debug) {
+        EmbedBuilder embed = new EmbedBuilder();
+        embed.setAuthor("Griddybot", null, GRIDDY_ICON_URL);
+        String prefix = debug ? "[DEBUG] " : "";
+        embed.setTitle(prefix + ":newspaper: The Griddybot Gazette — "
+                + LocalDate.now().format(DateTimeFormatter.ofPattern("d MMM yyyy")));
+
+        String standings = buildStandingsSection(report.standings());
+
+        if (report.article() == null || report.article().isBlank()) {
+            String quietMsg = "_All quiet on the Griddybot front this week. No new activity to report._";
+            embed.setDescription(quietMsg + "\n\n" + standings);
+            return embed;
+        }
+
+        embed.setDescription(fitWithinLimit(report.article(), standings));
+        return embed;
+    }
+
+    private String buildStandingsSection(List<SocialCredit> standings) {
+        if (standings == null || standings.isEmpty()) {
+            return "## :trophy: Standings\n_No standings yet._";
+        }
+        String[] medals = {":first_place:", ":second_place:", ":third_place:"};
+        StringBuilder sb = new StringBuilder("## :trophy: Standings\n");
+        for (int i = 0; i < standings.size(); i++) {
+            SocialCredit row = standings.get(i);
+            String medal = i < medals.length ? medals[i] + " " : "   ";
+            String deltaNote = row.getLastWeekDelta() == 0
+                    ? ""
+                    : String.format("  _(%+d)_", row.getLastWeekDelta());
+            sb.append(String.format("%s**%s** — %,d pts%s%n",
+                    medal, row.getUserTag(), row.getTotalPoints(), deltaNote));
+        }
+        return sb.toString();
+    }
+
+    private String fitWithinLimit(String article, String standings) {
+        String separator = "\n\n";
+        int available = EMBED_DESC_LIMIT - standings.length() - separator.length();
+        String body = article;
+        if (body.length() > available) {
+            int cut = Math.max(0, available - TRUNCATION_NOTE.length());
+            body = body.substring(0, cut) + TRUNCATION_NOTE;
+        }
+        return body + separator + standings;
     }
 }

--- a/src/main/java/com/dylansbogar/griddybot/utils/ServerEmoji.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/ServerEmoji.java
@@ -1,0 +1,41 @@
+package com.dylansbogar.griddybot.utils;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+// Custom emojis from the friend group's Discord server. Each entry pairs the
+// Discord emoji ID with a short description of how the group actually uses
+// it — these descriptions are surfaced to the LLM when interpreting message
+// reactions, so the model can tell the difference between e.g. a genuine
+// laugh (:OMEGALUL:) and a sarcastic one (:LAUGH:).
+//
+// Future features can target specific emojis by name, e.g. ServerEmoji.DUC.id.
+public enum ServerEmoji {
+    OMEGALUL(  "1082876655133020220", "very funny, often stupidly so — strong indicator of genuine humour"),
+    PEEPOLOVE( "886179492178034728",  "wholesome appreciation and affection — genuine love for the content"),
+    SADGE(     "988031909852487780",  "genuine sadness at sad news (e.g. someone passing away)"),
+    SHRUGE(    "1095214022711836752", "indifference / 'I dunno' / 'who cares'"),
+    DUC(       "1082878057444036678", "flirty, thirsty, or suggestive — reacting to something hot or attractive"),
+    COPIUM(    "1082876650007560324", "coping with a bad situation; denial or wishful thinking"),
+    LAUGH(     "1082877301521383474", "sarcastic mocking laugh — 'oh ha ha very funny' — this is NOT genuine humour, it's dismissive"),
+    DESPAIRGE( "1175759649786564718", "doom-and-gloom pessimism about world/news events — not personal sadness, more 'we are doomed'"),
+    LISADGE(   "988031906828394536",  "angry or mad reaction"),
+    SODGE(     "1122806123880267837", "exhausted exasperation, 'I am so over this' — done with the situation, not actually sad");
+
+    public final String id;
+    public final String description;
+
+    ServerEmoji(String id, String description) {
+        this.id = id;
+        this.description = description;
+    }
+
+    private static final Map<String, ServerEmoji> BY_ID = Arrays.stream(values())
+            .collect(Collectors.toMap(e -> e.id, e -> e));
+
+    public static Optional<ServerEmoji> byId(String id) {
+        return Optional.ofNullable(BY_ID.get(id));
+    }
+}

--- a/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditDebug.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditDebug.java
@@ -1,0 +1,39 @@
+package com.dylansbogar.griddybot.utils;
+
+// ============================================================
+// SOCIAL CREDIT — DEBUG CONFIGURATION
+//
+// Flip DEBUG_MODE to false for production.
+//
+// When DEBUG_MODE is true:
+//   - The weekly Monday cron is DISABLED.
+//   - A short-interval debug cron runs instead (DEBUG_CRON).
+//   - Message lookback window is DEBUG_WINDOW_HOURS (not 7 days),
+//     so testing doesn't require a week of seeded messages.
+//   - Per-user evaluation details (gathered messages, full prompt,
+//     raw LLM response, parsed result, errors) are written to the
+//     `social_credit_debug_log` Postgres table.
+//   - The Discord embed posted to the channel is prefixed with
+//     [DEBUG] so it's obvious it's a test run.
+//   - Run start/end and per-user summaries are printed to stdout
+//     (useful for `tail -f` on the bot's log).
+//
+// These must be compile-time constants so they can be referenced
+// from @Scheduled annotations. Rebuild after changing.
+// ============================================================
+public final class SocialCreditDebug {
+    public static final boolean DEBUG_MODE = true;
+
+    // Every 2 minutes. Examples:
+    //   "0 */2 * * * *"  — every 2 minutes
+    //   "0 */5 * * * *"  — every 5 minutes
+    //   "30 * * * * *"   — at 30 seconds past every minute
+    public static final String DEBUG_CRON = "0 */2 * * * *";
+
+    // How far back to look for messages when in debug mode.
+    // Keep this short so a quick test in a fresh channel still
+    // returns something interesting.
+    public static final int DEBUG_WINDOW_HOURS = 1;
+
+    private SocialCreditDebug() {}
+}

--- a/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public class SocialCreditService {
     private static final String API_URL = "https://openrouter.ai/api/v1/chat/completions";
     private static final String API_KEY = System.getenv("OPENROUTER_API_KEY");
-    private static final String EVAL_MODEL = "meta-llama/llama-3.2-3b-instruct";
+    private static final String EVAL_MODEL = "google/gemini-2.0-flash-001";
     private static final String EDITOR_MODEL = "minimax/minimax-m2.7";
     private static final String EDITOR_USER_ID = "__editor__";
     private static final int MAX_MESSAGES_PER_USER = 500;
@@ -583,15 +583,27 @@ public class SocialCreditService {
         HttpResponse<String> response = HttpClient.newHttpClient()
                 .send(request, HttpResponse.BodyHandlers.ofString());
 
-        JSONObject json = new JSONObject(response.body());
+        String responseBody = response.body();
+        JSONObject json;
+        try {
+            json = new JSONObject(responseBody);
+        } catch (Exception e) {
+            throw new RuntimeException("OpenRouter returned non-JSON response. Body:\n" + responseBody);
+        }
         if (json.has("error")) {
             throw new RuntimeException("OpenRouter error: "
-                    + json.getJSONObject("error").optString("message", "unknown"));
+                    + json.getJSONObject("error").optString("message", "unknown")
+                    + "\nFull response:\n" + json.toString(2));
         }
-        return json.getJSONArray("choices")
+
+        JSONObject message = json.getJSONArray("choices")
                 .getJSONObject(0)
-                .getJSONObject("message")
-                .getString("content");
+                .getJSONObject("message");
+        if (!message.has("content") || message.isNull("content")) {
+            throw new RuntimeException("OpenRouter returned no content. Full response:\n"
+                    + json.toString(2));
+        }
+        return message.getString("content");
     }
 
     private JSONObject extractJson(String raw) {

--- a/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
@@ -1,0 +1,624 @@
+package com.dylansbogar.griddybot.utils;
+
+import com.dylansbogar.griddybot.entities.SocialCredit;
+import com.dylansbogar.griddybot.entities.SocialCreditDebugLog;
+import com.dylansbogar.griddybot.repositories.SocialCreditDebugLogRepository;
+import com.dylansbogar.griddybot.repositories.SocialCreditRepository;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageReaction;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SocialCreditService {
+    private static final String API_URL = "https://openrouter.ai/api/v1/chat/completions";
+    private static final String API_KEY = System.getenv("OPENROUTER_API_KEY");
+    private static final String EVAL_MODEL = "meta-llama/llama-3.2-3b-instruct";
+    private static final String EDITOR_MODEL = "minimax/minimax-m2.7";
+    private static final String EDITOR_USER_ID = "__editor__";
+    private static final int MAX_MESSAGES_PER_USER = 500;
+    private static final int MIN_DELTA = -100;
+    private static final int MAX_DELTA = 100;
+
+    // Inactivity tracking — see CLAUDE.md / README for rationale.
+    private static final int INACTIVITY_FLOOR = 50;
+    private static final double INACTIVITY_THRESHOLD_FRACTION = 0.30;
+    private static final int QUIET_PENALTY = -10;
+    private static final int ABSENT_PENALTY = -20;
+
+    // Reaction tiers — bot self-reactions are subtracted before tiering.
+    private static final int REACTION_TIER_GOOD = 3;
+    private static final int REACTION_TIER_BETTER = 4;
+    private static final int REACTION_TIER_LEGENDARY = 5;
+
+    private static final Pattern JSON_OBJECT = Pattern.compile("\\{.*}", Pattern.DOTALL);
+
+    private final SocialCreditRepository creditRepo;
+    private final SocialCreditDebugLogRepository debugLogRepo;
+
+    public WeeklyReport evaluateWeek(MessageChannel channel) {
+        boolean debug = SocialCreditDebug.DEBUG_MODE;
+        Instant runAt = Instant.now();
+        Instant cutoff = debug
+                ? runAt.minus(SocialCreditDebug.DEBUG_WINDOW_HOURS, ChronoUnit.HOURS)
+                : runAt.minus(7, ChronoUnit.DAYS);
+
+        log(debug, "Social credit run starting at " + runAt + " (window cutoff: " + cutoff + ")");
+
+        List<Message> weekMessages;
+        try {
+            weekMessages = channel.getIterableHistory()
+                    .takeWhileAsync(m -> m.getTimeCreated().toInstant().isAfter(cutoff))
+                    .join();
+        } catch (Exception e) {
+            System.out.println("Failed to fetch channel history: " + e.getMessage());
+            return new WeeklyReport(null, creditRepo.findAllByOrderByTotalPointsDesc());
+        }
+
+        log(debug, "Fetched " + weekMessages.size() + " messages from channel");
+
+        // In production, only regulars are tracked. In debug mode the friend
+        // is testing in his own channel without the production roster, so we
+        // evaluate anyone who posts.
+        //
+        // Messages from alias accounts (e.g. Matt's alt) are attributed to
+        // the canonical user — they appear in the canonical user's evaluation
+        // and message count, and the alias never gets its own scoreline.
+        Map<String, List<Message>> byCanonicalId = weekMessages.stream()
+                .filter(m -> !m.getAuthor().isBot())
+                .filter(m -> !m.getContentRaw().isBlank())
+                .filter(m -> {
+                    if (debug) return true;
+                    String canonId = UserConstants.canonicalUserId(m.getAuthor().getId());
+                    return UserConstants.REGULAR_USER_IDS.contains(canonId);
+                })
+                .collect(Collectors.groupingBy(
+                        m -> UserConstants.canonicalUserId(m.getAuthor().getId())));
+
+        log(debug, "Active users this window: " + byCanonicalId.size());
+
+        // Phase 1: per-user LLM eval (no DB writes yet)
+        List<UserResult> preAdjust = new ArrayList<>();
+        Map<String, Integer> msgCounts = new HashMap<>();
+        for (Map.Entry<String, List<Message>> entry : byCanonicalId.entrySet()) {
+            String canonId = entry.getKey();
+            List<Message> messages = entry.getValue();
+            msgCounts.put(canonId, messages.size());
+            User canonicalUser = resolveCanonicalUser(canonId, messages, channel);
+            UserResult result = evaluateUser(canonicalUser, messages, debug, runAt);
+            if (result != null) preAdjust.add(result);
+        }
+
+        // Phase 2: apply inactivity adjustments (production only — debug runs
+        // in a test channel where the production roster isn't posting).
+        List<UserResult> adjusted = debug
+                ? preAdjust
+                : applyInactivityAdjustments(preAdjust, msgCounts, channel, debug);
+
+        // Phase 3: upsert all results (including any synthetic absentees)
+        List<UserResult> results = new ArrayList<>();
+        for (UserResult r : adjusted) {
+            int newTotal = upsert(r);
+            results.add(new UserResult(r.userId(), r.userTag(), r.delta(),
+                    r.reasoning(), r.highlights(), newTotal));
+            log(debug, String.format("  %s: delta=%+d, newTotal=%d",
+                    r.userTag(), r.delta(), newTotal));
+        }
+
+        String article = results.isEmpty() ? null : composeNewsReport(results, debug, runAt);
+        List<SocialCredit> standings = creditRepo.findAllByOrderByTotalPointsDesc();
+
+        log(debug, "Social credit run finished at " + Instant.now());
+        return new WeeklyReport(article, standings);
+    }
+
+    private List<UserResult> applyInactivityAdjustments(List<UserResult> evaluated,
+                                                       Map<String, Integer> msgCounts,
+                                                       MessageChannel channel,
+                                                       boolean debug) {
+        if (msgCounts.isEmpty()) return evaluated;
+
+        List<Integer> sortedCounts = msgCounts.values().stream().sorted().toList();
+        double median = sortedCounts.size() % 2 == 0
+                ? (sortedCounts.get(sortedCounts.size() / 2 - 1)
+                    + sortedCounts.get(sortedCounts.size() / 2)) / 2.0
+                : sortedCounts.get(sortedCounts.size() / 2);
+
+        if (median < INACTIVITY_FLOOR) {
+            log(debug, "Inactivity check skipped: median " + median
+                    + " < floor " + INACTIVITY_FLOOR);
+            return evaluated;
+        }
+
+        double quietThreshold = median * INACTIVITY_THRESHOLD_FRACTION;
+        log(debug, "Inactivity check: median=" + median
+                + ", quiet threshold=" + quietThreshold);
+
+        List<UserResult> adjusted = new ArrayList<>();
+        Set<String> evaluatedIds = new HashSet<>();
+        for (UserResult r : evaluated) {
+            evaluatedIds.add(r.userId());
+            int count = msgCounts.getOrDefault(r.userId(), 0);
+            if (count < quietThreshold) {
+                log(debug, "  QUIET: " + r.userTag() + " (" + count
+                        + " msgs < threshold " + quietThreshold + ")");
+                List<String> newHighlights = new ArrayList<>(r.highlights());
+                newHighlights.add(String.format(
+                        "(was unusually quiet — only %d messages this week vs group median of %d)",
+                        count, (int) median));
+                adjusted.add(new UserResult(r.userId(), r.userTag(),
+                        r.delta() + QUIET_PENALTY, r.reasoning(), newHighlights, 0));
+            } else {
+                adjusted.add(r);
+            }
+        }
+
+        // Add synthetic absentees: any regular who posted nothing this week.
+        for (String regularId : UserConstants.REGULAR_USER_IDS) {
+            if (evaluatedIds.contains(regularId)) continue;
+            String tag = resolveUserTag(channel, regularId);
+            log(debug, "  ABSENT: " + tag);
+            adjusted.add(new UserResult(
+                    regularId, tag, ABSENT_PENALTY,
+                    "Conspicuously absent from the server this week.",
+                    List.of(String.format(
+                            "(was completely absent — posted 0 messages this week, group median was %d)",
+                            (int) median)),
+                    0));
+        }
+
+        return adjusted;
+    }
+
+    // Returns the User object for the canonical account. Prefers a User
+    // already present in the fetched messages (avoids a REST call when the
+    // canonical account posted at least once this week); falls back to a
+    // JDA lookup when only an alias posted; last-resort uses any author
+    // from the messages list (better than crashing).
+    private User resolveCanonicalUser(String canonId, List<Message> messages, MessageChannel channel) {
+        return messages.stream()
+                .map(Message::getAuthor)
+                .filter(u -> u.getId().equals(canonId))
+                .findFirst()
+                .orElseGet(() -> {
+                    try {
+                        return channel.getJDA().retrieveUserById(canonId).complete();
+                    } catch (Exception e) {
+                        System.out.println("Failed to resolve canonical user " + canonId
+                                + ", falling back to first message author: " + e.getMessage());
+                        return messages.get(0).getAuthor();
+                    }
+                });
+    }
+
+    private String resolveUserTag(MessageChannel channel, String userId) {
+        try {
+            return channel.getJDA().retrieveUserById(userId).complete().getAsTag();
+        } catch (Exception e) {
+            return creditRepo.findById(userId)
+                    .map(SocialCredit::getUserTag)
+                    .orElse("user " + userId);
+        }
+    }
+
+    private UserResult evaluateUser(User user, List<Message> messages, boolean debug, Instant runAt) {
+        List<Message> capped = messages.size() > MAX_MESSAGES_PER_USER
+                ? messages.subList(messages.size() - MAX_MESSAGES_PER_USER, messages.size())
+                : messages;
+
+        capped.sort(Comparator.comparing(Message::getTimeCreated));
+        DateTimeFormatter timeFmt = DateTimeFormatter.ofPattern("EEE HH:mm");
+        StringBuilder convo = new StringBuilder();
+        for (Message m : capped) {
+            convo.append("[").append(m.getTimeCreated().format(timeFmt)).append("] ")
+                    .append(m.getContentRaw()).append("\n");
+        }
+
+        boolean stern = UserConstants.STERN_BIAS_IDS.contains(user.getId());
+        String topReactedSection = buildTopReactedSection(findTopReacted(capped));
+        String prompt = buildPrompt(user.getAsTag(), convo.toString(), topReactedSection, stern);
+
+        String raw = null;
+        try {
+            raw = callOpenRouter(prompt, EVAL_MODEL);
+            JSONObject json = extractJson(raw);
+            int delta = clamp(json.getInt("delta"));
+            String reasoning = json.optString("reasoning", "(no reasoning given)");
+            List<String> highlights = parseHighlights(json);
+            if (debug) {
+                saveDebugLog(runAt, user, stern, capped.size(), convo.toString(), prompt, raw,
+                        delta, reasoning, null);
+            }
+            return new UserResult(user.getId(), user.getAsTag(), delta, reasoning, highlights, 0);
+        } catch (Exception e) {
+            System.out.println("Failed to evaluate " + user.getAsTag() + ": " + e.getMessage());
+            if (debug) {
+                saveDebugLog(runAt, user, stern, capped.size(), convo.toString(), prompt, raw,
+                        null, null, e.getMessage());
+            }
+            return null;
+        }
+    }
+
+    private String composeNewsReport(List<UserResult> results, boolean debug, Instant runAt) {
+        String prompt = buildEditorPrompt(results);
+        String raw = null;
+        try {
+            raw = callOpenRouter(prompt, EDITOR_MODEL);
+            if (debug) saveEditorDebugLog(runAt, prompt, raw, null);
+            return raw.trim();
+        } catch (Exception e) {
+            System.out.println("Failed to compose news report: " + e.getMessage());
+            if (debug) saveEditorDebugLog(runAt, prompt, raw, e.getMessage());
+            // Fallback: a plain bullet list so the recap still posts.
+            StringBuilder fallback = new StringBuilder();
+            for (UserResult r : results) {
+                fallback.append("**").append(r.userTag()).append("** (")
+                        .append(String.format("%+d", r.delta())).append("): ")
+                        .append(r.reasoning()).append("\n");
+            }
+            return fallback.toString();
+        }
+    }
+
+    private String buildEditorPrompt(List<UserResult> results) {
+        StringBuilder p = new StringBuilder();
+        p.append("You are the editor of a sensationalist 1920s newspaper, ")
+                .append("\"The Griddybot Gazette\", reporting on this week's antics in a ")
+                .append("private Discord friend group. Write the week's report.\n\n")
+                .append("FORMAT:\n")
+                .append("- For each user below, write an ALL-CAPS BOLD HEADLINE in markdown ")
+                .append("(**LIKE THIS**) followed by a 1-2 sentence article body in normal prose.\n")
+                .append("- Punchy, theatrical, melodramatic — think \"BRODEY ACHIEVES MIRACULOUS ")
+                .append("SLAM-DUNK, MEMBERS GASP IN AWE\" for triumphs, or \"LOCAL MAN COMPLAINS ")
+                .append("OF WORK FOURTEENTH TIME THIS WEEK\" for negative weeks.\n")
+                .append("- Tone depends on the delta:\n")
+                .append("    * Positive delta → triumphant, celebratory, awestruck.\n")
+                .append("    * Negative delta → disappointed, scolding, mock-tragic, gossipy.\n")
+                .append("    * Near-zero delta → quietly amused, mundane.\n")
+                .append("- Use ONLY the highlights provided. Do not invent events. You may ")
+                .append("embellish the prose for flair, but the underlying facts must come from ")
+                .append("the highlights.\n")
+                .append("- Separate each user's section with a blank line.\n")
+                .append("- Do NOT write a STANDINGS section, leaderboard, summary, or table. ")
+                .append("Just the headlines and article bodies. The standings are appended ")
+                .append("separately by the typesetter.\n")
+                .append("- Do NOT mention strictness, stern evaluation, bias, special rules, or ")
+                .append("that any user is being judged differently. All users are reported on ")
+                .append("equally — their headline tone is determined purely by their delta.\n")
+                .append("- Do NOT include any preamble like \"Here is the report\" — just start ")
+                .append("with the first headline.\n\n")
+                .append("USERS:\n\n");
+
+        for (UserResult r : results) {
+            p.append("---\n")
+                    .append("User: ").append(r.userTag()).append("\n")
+                    .append("Delta: ").append(String.format("%+d", r.delta())).append("\n")
+                    .append("Highlights:\n");
+            if (r.highlights().isEmpty()) {
+                p.append("  - (none — write a brief headline noting they were quiet this week)\n");
+            } else {
+                for (String h : r.highlights()) {
+                    p.append("  - ").append(h).append("\n");
+                }
+            }
+            p.append("\n");
+        }
+        return p.toString();
+    }
+
+    private void saveEditorDebugLog(Instant runAt, String prompt, String llmResponse, String error) {
+        try {
+            debugLogRepo.save(SocialCreditDebugLog.builder()
+                    .runAt(runAt)
+                    .userId(EDITOR_USER_ID)
+                    .userTag("(news editor)")
+                    .sternBias(false)
+                    .messageCount(0)
+                    .gatheredMessages(null)
+                    .prompt(prompt)
+                    .llmResponse(llmResponse)
+                    .parsedDelta(null)
+                    .parsedReasoning(null)
+                    .error(error)
+                    .build());
+        } catch (Exception ex) {
+            System.out.println("Failed to save editor debug log row: " + ex.getMessage());
+        }
+    }
+
+    private record ReactedMessage(Message message, int effectiveCount, String reactionSummary,
+                                  boolean selfReact) {}
+
+    // Returns messages with effective reaction count >= REACTION_TIER_GOOD,
+    // sorted by count descending. "Effective" = total reactions minus bot
+    // self-reactions (Griddybot reacts to bullies via ReactionService — we
+    // don't want being bullied to look like popularity).
+    //
+    // Each qualifying message is also checked for self-reactions (the author
+    // reacted to their own message). This requires one REST call per
+    // reaction type, short-circuited the moment the author is found.
+    private List<ReactedMessage> findTopReacted(List<Message> messages) {
+        List<ReactedMessage> out = new ArrayList<>();
+        for (Message m : messages) {
+            int total = 0;
+            StringBuilder summary = new StringBuilder();
+            for (MessageReaction r : m.getReactions()) {
+                int effective = r.getCount() - (r.isSelf() ? 1 : 0);
+                if (effective <= 0) continue;
+                total += effective;
+                if (summary.length() > 0) summary.append(" ");
+                summary.append(formatEmoji(r.getEmoji())).append("×").append(effective);
+            }
+            if (total >= REACTION_TIER_GOOD) {
+                boolean selfReact = authorReactedToOwnMessage(m);
+                out.add(new ReactedMessage(m, total, summary.toString(), selfReact));
+            }
+        }
+        out.sort(Comparator.comparingInt(ReactedMessage::effectiveCount).reversed());
+        return out;
+    }
+
+    private boolean authorReactedToOwnMessage(Message m) {
+        String authorId = m.getAuthor().getId();
+        for (MessageReaction r : m.getReactions()) {
+            try {
+                List<User> users = r.retrieveUsers().complete();
+                for (User u : users) {
+                    if (u.getId().equals(authorId)) return true;
+                }
+            } catch (Exception e) {
+                // A single reaction-users lookup failing shouldn't break the
+                // whole evaluation; just skip it and assume not self-react.
+                System.out.println("Failed to retrieve users for reaction: " + e.getMessage());
+            }
+        }
+        return false;
+    }
+
+    private String formatEmoji(Emoji emoji) {
+        if (emoji.getType() == Emoji.Type.UNICODE) {
+            return emoji.getName();
+        }
+        if (emoji.getType() == Emoji.Type.CUSTOM) {
+            return ":" + emoji.getName() + ":";
+        }
+        return ":" + emoji.getName() + ":";
+    }
+
+    // Extracts every custom server emoji that appears across the given
+    // reacted messages and produces a glossary block explaining what each
+    // means. Returned empty if no recognised server emojis are used.
+    private String buildEmojiGlossary(List<ReactedMessage> topReacted) {
+        Set<ServerEmoji> seen = new LinkedHashSet<>();
+        for (ReactedMessage rm : topReacted) {
+            for (MessageReaction r : rm.message().getReactions()) {
+                if (r.getEmoji().getType() != Emoji.Type.CUSTOM) continue;
+                ServerEmoji.byId(r.getEmoji().asCustom().getId()).ifPresent(seen::add);
+            }
+        }
+        if (seen.isEmpty()) return "";
+        StringBuilder s = new StringBuilder("EMOJI GLOSSARY (custom server emojis used below — ");
+        s.append("interpret reactions in light of these meanings):\n");
+        for (ServerEmoji e : seen) {
+            s.append("  :").append(e.name()).append(": = ").append(e.description).append("\n");
+        }
+        s.append("\n");
+        return s.toString();
+    }
+
+    private String tierLabel(int count, boolean selfReact) {
+        if (selfReact) return "SELF-REACT (cringe)";
+        if (count >= REACTION_TIER_LEGENDARY) return "LEGENDARY";
+        if (count >= REACTION_TIER_BETTER) return "BETTER";
+        return "GOOD";
+    }
+
+    private String buildTopReactedSection(List<ReactedMessage> topReacted) {
+        if (topReacted.isEmpty()) return "";
+        DateTimeFormatter timeFmt = DateTimeFormatter.ofPattern("EEE HH:mm");
+        StringBuilder s = new StringBuilder();
+        s.append(buildEmojiGlossary(topReacted))
+                .append(":star: TOP-REACTED MESSAGES THIS WEEK\n")
+                .append("The following messages from this user received notable engagement from ")
+                .append("other members. Use the reaction tier to calibrate how much to weight ")
+                .append("each one when scoring. You MUST include each of these messages as a ")
+                .append("highlight in your response so the newspaper editor can write about them.\n\n")
+                .append("Tiers:\n")
+                .append("- LEGENDARY (5+ reactions): a major moment. Should drive a noticeably ")
+                .append("positive delta and the highlight should be vivid and quotable so the ")
+                .append("editor gives it top billing.\n")
+                .append("- BETTER (4 reactions): a clearly popular moment. Notable weight in ")
+                .append("scoring; deserves a dedicated, well-written highlight.\n")
+                .append("- GOOD (3 reactions): modest popularity. Small positive nudge to the ")
+                .append("score; include as a brief highlight.\n")
+                .append("- SELF-REACT (cringe): the user reacted to THEIR OWN message. This is ")
+                .append("cringe regardless of how many others also reacted — it overrides any ")
+                .append("other tier. Apply a small NEGATIVE delta and write a mocking highlight ")
+                .append("calling them out for reacting to themselves. The newspaper editor will ")
+                .append("then write a roast headline. Do NOT reward this even if other people ")
+                .append("genuinely engaged with the message — the cringe of self-reacting ")
+                .append("outweighs the popularity.\n\n")
+                .append("IMPORTANT: If a top-reacted message was mean-spirited, cruel, or punching ")
+                .append("down (even if popular), do NOT reward it. Reactions confirm engagement, ")
+                .append("not goodness. Score it accordingly but still mention it in highlights.\n\n")
+                .append("Messages:\n");
+        for (ReactedMessage rm : topReacted) {
+            s.append("- [").append(tierLabel(rm.effectiveCount(), rm.selfReact())).append("] ")
+                    .append("[").append(rm.message().getTimeCreated().format(timeFmt)).append("] ")
+                    .append(rm.reactionSummary()).append(" (")
+                    .append(rm.effectiveCount()).append(" total");
+            if (rm.selfReact()) {
+                s.append(" — INCLUDING ONE FROM THE USER THEMSELF");
+            }
+            s.append(") — \"")
+                    .append(rm.message().getContentRaw().replace("\n", " "))
+                    .append("\"\n");
+        }
+        s.append("\n");
+        return s.toString();
+    }
+
+    private List<String> parseHighlights(JSONObject json) {
+        List<String> out = new ArrayList<>();
+        if (!json.has("highlights")) return out;
+        JSONArray arr = json.optJSONArray("highlights");
+        if (arr == null) return out;
+        for (int i = 0; i < arr.length(); i++) {
+            String s = arr.optString(i, null);
+            if (s != null && !s.isBlank()) out.add(s);
+        }
+        return out;
+    }
+
+    private void saveDebugLog(Instant runAt, User user, boolean stern, int messageCount,
+                              String gathered, String prompt, String llmResponse,
+                              Integer delta, String reasoning, String error) {
+        try {
+            debugLogRepo.save(SocialCreditDebugLog.builder()
+                    .runAt(runAt)
+                    .userId(user.getId())
+                    .userTag(user.getAsTag())
+                    .sternBias(stern)
+                    .messageCount(messageCount)
+                    .gatheredMessages(gathered)
+                    .prompt(prompt)
+                    .llmResponse(llmResponse)
+                    .parsedDelta(delta)
+                    .parsedReasoning(reasoning)
+                    .error(error)
+                    .build());
+        } catch (Exception ex) {
+            System.out.println("Failed to save debug log row: " + ex.getMessage());
+        }
+    }
+
+    private void log(boolean debug, String msg) {
+        if (debug) System.out.println("[social-credit-debug] " + msg);
+    }
+
+    private String buildPrompt(String userTag, String messages, String topReactedSection, boolean stern) {
+        StringBuilder p = new StringBuilder();
+        p.append("You are evaluating one week of Discord messages from a single user for a ")
+                .append("playful \"social credit\" score among friends. Read the messages and return ")
+                .append("ONLY a JSON object with this exact shape (no markdown, no prose):\n\n")
+                .append("{\n")
+                .append("  \"delta\": <integer between -100 and 100>,\n")
+                .append("  \"reasoning\": \"<one sentence explaining the score>\",\n")
+                .append("  \"highlights\": [\"<concrete event 1>\", \"<concrete event 2>\", \"...\"]\n")
+                .append("}\n\n")
+                .append("Highlights guidance — VERY IMPORTANT, these are used to write a newspaper ")
+                .append("article later:\n")
+                .append("- Return 2 to 4 highlights when there is enough material; 1 is fine for a quiet week.\n")
+                .append("- Each highlight must describe a SPECIFIC, CONCRETE thing the user said or did ")
+                .append("this week. Quote or paraphrase real messages. Include numbers/names/details ")
+                .append("when present (e.g. \"cooked their first lasagna and sent a photo\", ")
+                .append("\"helped Dylan debug a Spring Boot issue at 2am\", \"complained about work 14 times\").\n")
+                .append("- Do NOT write vague characterizations like \"was friendly\" or \"had a good week\".\n")
+                .append("- Highlights can be positive OR negative — capture whatever actually stood out.\n\n")
+                .append("Scoring guidance:\n")
+                .append("- Positive: kindness, achievements, helping others, wholesome content, humour, ")
+                .append("cooking/learning/doing genuinely cool things.\n")
+                .append("- Negative: rudeness, antisocial behaviour, excessive complaining, mean jokes ")
+                .append("that punch down.\n")
+                .append("- A truly average / mixed week should land near 0.\n\n");
+
+        if (stern) {
+            p.append("SPECIAL RULE FOR THIS USER:\n")
+                    .append("This user is being evaluated more strictly as a running joke among friends. ")
+                    .append("Only award positive points if they did something genuinely good, morally ")
+                    .append("correct, and objectively nice (e.g. concrete acts of kindness, real ")
+                    .append("achievements, helping others). For anything average, mildly negative, or ")
+                    .append("ambiguous, lean negative. Do NOT reward mere humour, banter, or \"not being ")
+                    .append("bad\". Default posture is stern; positive scores must be earned.\n\n")
+                    .append("IMPORTANT: This special rule is a secret. The user must not know they are ")
+                    .append("being judged more strictly. Your reasoning text must read like a normal, ")
+                    .append("neutral evaluation of their week. Do NOT mention strictness, stern ")
+                    .append("evaluation, special rules, bias, or that they are being held to a higher ")
+                    .append("standard. Do NOT use words like \"stern\", \"strict\", \"harsh\", or ")
+                    .append("\"special\" in the reasoning. Just describe what they did or didn't do.\n\n");
+        }
+
+        if (topReactedSection != null && !topReactedSection.isEmpty()) {
+            p.append(topReactedSection);
+        }
+
+        p.append("User: ").append(userTag).append("\n")
+                .append("Messages this week:\n")
+                .append(messages);
+        return p.toString();
+    }
+
+    private String callOpenRouter(String prompt, String model) throws Exception {
+        JSONObject body = new JSONObject()
+                .put("model", model)
+                .put("messages", new JSONArray()
+                        .put(new JSONObject().put("role", "user").put("content", prompt)));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(API_URL))
+                .header("Authorization", "Bearer " + API_KEY)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+                .build();
+
+        HttpResponse<String> response = HttpClient.newHttpClient()
+                .send(request, HttpResponse.BodyHandlers.ofString());
+
+        JSONObject json = new JSONObject(response.body());
+        if (json.has("error")) {
+            throw new RuntimeException("OpenRouter error: "
+                    + json.getJSONObject("error").optString("message", "unknown"));
+        }
+        return json.getJSONArray("choices")
+                .getJSONObject(0)
+                .getJSONObject("message")
+                .getString("content");
+    }
+
+    private JSONObject extractJson(String raw) {
+        Matcher m = JSON_OBJECT.matcher(raw);
+        if (!m.find()) {
+            throw new RuntimeException("no JSON object in model response: " + raw);
+        }
+        return new JSONObject(m.group());
+    }
+
+    private int clamp(int delta) {
+        return Math.max(MIN_DELTA, Math.min(MAX_DELTA, delta));
+    }
+
+    private int upsert(UserResult r) {
+        SocialCredit row = creditRepo.findById(r.userId())
+                .orElse(new SocialCredit(r.userId(), r.userTag(), 0, 0, "", null));
+        row.setTotalPoints(row.getTotalPoints() + r.delta());
+        row.setLastWeekDelta(r.delta());
+        row.setLastWeekReason(r.reasoning());
+        row.setUserTag(r.userTag());
+        row.setLastEvaluatedAt(Instant.now());
+        creditRepo.save(row);
+        return row.getTotalPoints();
+    }
+
+    public record UserResult(String userId, String userTag, int delta, String reasoning,
+                             List<String> highlights, int newTotal) {}
+    public record WeeklyReport(String article, List<SocialCredit> standings) {}
+}

--- a/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.entities.sticker.StickerItem;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.stereotype.Service;
@@ -83,12 +84,13 @@ public class SocialCreditService {
 
         // Filter to tracked authors (regulars only in production; anyone in
         // debug, since the friend tests in his own channel without the roster),
-        // skip bots and blank content, and sort chronologically so the whole
+        // skip bots and truly empty messages (kept if they carry text, an
+        // attachment, or a sticker), and sort chronologically so the whole
         // week reads as one conversation. Alias accounts (e.g. Matt's alt) are
         // collapsed to the canonical user everywhere downstream.
         List<Message> tracked = weekMessages.stream()
                 .filter(m -> !m.getAuthor().isBot())
-                .filter(m -> !m.getContentRaw().isBlank())
+                .filter(this::hasContent)
                 .filter(m -> {
                     if (debug) return true;
                     String canonId = UserConstants.canonicalUserId(m.getAuthor().getId());
@@ -191,7 +193,38 @@ public class SocialCreditService {
             String name = roster.getOrDefault(canonId, m.getAuthor().getAsTag());
             sb.append("[").append(m.getTimeCreated().format(timeFmt)).append("] ")
                     .append(name).append(" (").append(canonId).append("): ")
-                    .append(m.getContentRaw().replace("\n", " ")).append("\n");
+                    .append(renderMessageContent(m)).append("\n");
+        }
+        return sb.toString();
+    }
+
+    // A message "counts" if it has text, OR carries media (an image/file/video
+    // attachment or a sticker) even with no caption. Image- and sticker-only
+    // messages are a big part of how the group actually communicates, so they
+    // must feed the transcript, the reaction tiers, and the activity counts —
+    // not get dropped as "blank" the way a raw getContentRaw().isBlank() check
+    // would drop them.
+    private boolean hasContent(Message m) {
+        return !m.getContentRaw().isBlank()
+                || !m.getAttachments().isEmpty()
+                || !m.getStickers().isEmpty();
+    }
+
+    // Renders a message as one transcript-safe line: its text (newlines
+    // flattened) followed by bracketed placeholders for any attachments or
+    // stickers, so an image- or sticker-only message still reads as a real
+    // event (e.g. "[image: cursed_cat.png]") instead of an empty string the
+    // model would silently skip over.
+    private String renderMessageContent(Message m) {
+        StringBuilder sb = new StringBuilder(m.getContentRaw().replace("\n", " ").trim());
+        for (Message.Attachment a : m.getAttachments()) {
+            if (sb.length() > 0) sb.append(" ");
+            String kind = a.isImage() ? "image" : a.isVideo() ? "video" : "file";
+            sb.append("[").append(kind).append(": ").append(a.getFileName()).append("]");
+        }
+        for (StickerItem s : m.getStickers()) {
+            if (sb.length() > 0) sb.append(" ");
+            sb.append("[sticker: ").append(s.getName()).append("]");
         }
         return sb.toString();
     }
@@ -377,7 +410,7 @@ public class SocialCreditService {
     private String buildEditorPrompt(List<UserResult> results) {
         StringBuilder p = new StringBuilder();
         p.append("You are the editor of a sensationalist 1920s newspaper, ")
-                .append("\"The Griddybot Gazette\", reporting on this week's antics in a ")
+                .append("\"The Griddy Gazette\", reporting on this week's antics in a ")
                 .append("private Discord friend group. Write the week's report.\n\n")
                 .append("FORMAT:\n")
                 .append("- For each user below, write an ALL-CAPS BOLD HEADLINE in markdown ")
@@ -445,7 +478,7 @@ public class SocialCreditService {
 
     // Returns messages with effective reaction count >= REACTION_TIER_GOOD,
     // sorted by count descending. "Effective" = total reactions minus bot
-    // self-reactions (Griddybot reacts to bullies via ReactionService — we
+    // self-reactions (Griddy reacts to bullies via ReactionService — we
     // don't want being bullied to look like popularity).
     //
     // Each qualifying message is also checked for self-reactions (the author
@@ -572,7 +605,7 @@ public class SocialCreditService {
                 s.append(" — INCLUDING ONE FROM THE AUTHOR THEMSELF");
             }
             s.append(") — \"")
-                    .append(rm.message().getContentRaw().replace("\n", " "))
+                    .append(renderMessageContent(rm.message()))
                     .append("\"\n");
         }
         s.append("\n");

--- a/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
@@ -34,7 +34,13 @@ public class SocialCreditService {
     private static final String EVAL_MODEL = "google/gemini-2.0-flash-001";
     private static final String EDITOR_MODEL = "minimax/minimax-m2.7";
     private static final String EDITOR_USER_ID = "__editor__";
-    private static final int MAX_MESSAGES_PER_USER = 500;
+    private static final String EVAL_USER_ID = "__eval__";
+    // Global safety cap on the single conversation prompt. Far above the
+    // realistic ~700 msgs/week — only trims a runaway week.
+    private static final int MAX_MESSAGES_TOTAL = 2000;
+    // The single whole-conversation call is one point of failure for the whole
+    // week, so it gets retried: 1 attempt + 2 retries = 3 total.
+    private static final int MAX_ATTEMPTS = 3;
     private static final int MIN_DELTA = -100;
     private static final int MAX_DELTA = 100;
 
@@ -75,14 +81,12 @@ public class SocialCreditService {
 
         log(debug, "Fetched " + weekMessages.size() + " messages from channel");
 
-        // In production, only regulars are tracked. In debug mode the friend
-        // is testing in his own channel without the production roster, so we
-        // evaluate anyone who posts.
-        //
-        // Messages from alias accounts (e.g. Matt's alt) are attributed to
-        // the canonical user — they appear in the canonical user's evaluation
-        // and message count, and the alias never gets its own scoreline.
-        Map<String, List<Message>> byCanonicalId = weekMessages.stream()
+        // Filter to tracked authors (regulars only in production; anyone in
+        // debug, since the friend tests in his own channel without the roster),
+        // skip bots and blank content, and sort chronologically so the whole
+        // week reads as one conversation. Alias accounts (e.g. Matt's alt) are
+        // collapsed to the canonical user everywhere downstream.
+        List<Message> tracked = weekMessages.stream()
                 .filter(m -> !m.getAuthor().isBot())
                 .filter(m -> !m.getContentRaw().isBlank())
                 .filter(m -> {
@@ -90,22 +94,57 @@ public class SocialCreditService {
                     String canonId = UserConstants.canonicalUserId(m.getAuthor().getId());
                     return UserConstants.REGULAR_USER_IDS.contains(canonId);
                 })
+                .sorted(Comparator.comparing(Message::getTimeCreated))
+                .collect(Collectors.toList());
+
+        List<Message> capped = capTotal(tracked, MAX_MESSAGES_TOTAL);
+        boolean capApplied = tracked.size() > MAX_MESSAGES_TOTAL;
+        RunStats stats = new RunStats(
+                weekMessages.size(), tracked.size(), capped.size(), capApplied);
+
+        // Group by canonical user — used only for per-user message counts
+        // (the inactivity phase) and to resolve each canonical user's display
+        // name for the roster. It is NOT the unit of evaluation anymore.
+        Map<String, List<Message>> byCanonId = capped.stream()
                 .collect(Collectors.groupingBy(
                         m -> UserConstants.canonicalUserId(m.getAuthor().getId())));
 
-        log(debug, "Active users this window: " + byCanonicalId.size());
+        log(debug, "Messages: fetched=" + stats.fetched() + ", tracked=" + stats.tracked()
+                + ", evaluated=" + stats.evaluated() + ", active users=" + byCanonId.size()
+                + (capApplied ? "  *** CAP HIT — raise MAX_MESSAGES_TOTAL ***" : ""));
 
-        // Phase 1: per-user LLM eval (no DB writes yet)
-        List<UserResult> preAdjust = new ArrayList<>();
-        Map<String, Integer> msgCounts = new HashMap<>();
-        for (Map.Entry<String, List<Message>> entry : byCanonicalId.entrySet()) {
-            String canonId = entry.getKey();
-            List<Message> messages = entry.getValue();
-            msgCounts.put(canonId, messages.size());
-            User canonicalUser = resolveCanonicalUser(canonId, messages, channel);
-            UserResult result = evaluateUser(canonicalUser, messages, debug, runAt);
-            if (result != null) preAdjust.add(result);
+        if (byCanonId.isEmpty()) {
+            log(debug, "No tracked messages this window; nothing to evaluate.");
+            return new WeeklyReport(null, creditRepo.findAllByOrderByTotalPointsDesc());
         }
+
+        Map<String, Integer> msgCounts = new HashMap<>();
+        Map<String, String> roster = new LinkedHashMap<>();
+        for (Map.Entry<String, List<Message>> entry : byCanonId.entrySet()) {
+            String canonId = entry.getKey();
+            msgCounts.put(canonId, entry.getValue().size());
+            User canonicalUser = resolveCanonicalUser(canonId, entry.getValue(), channel);
+            roster.put(canonId, canonicalUser.getAsTag());
+        }
+
+        String transcript = buildTranscript(capped, roster);
+        String topReactedSection = buildTopReactedSection(findTopReacted(capped), roster);
+        String prompt = buildPrompt(roster, transcript, topReactedSection);
+
+        // Phase 1: single whole-conversation eval (up to 3 attempts).
+        List<UserResult> preAdjust = evaluateConversation(
+                prompt, roster, debug, runAt, stats, transcript);
+        if (preAdjust == null) {
+            // All retries exhausted — abort cleanly. Write nothing, post the
+            // quiet embed rather than a broken or guessed recap.
+            log(debug, "Aborting run: evaluation failed after " + MAX_ATTEMPTS + " attempts.");
+            return new WeeklyReport(null, creditRepo.findAllByOrderByTotalPointsDesc());
+        }
+
+        // Raw (model) delta per user, captured before inactivity adjustments so
+        // the debug log can show raw vs final and explain any gap.
+        Map<String, Integer> rawDeltas = preAdjust.stream()
+                .collect(Collectors.toMap(UserResult::userId, UserResult::delta));
 
         // Phase 2: apply inactivity adjustments (production only — debug runs
         // in a test channel where the production roster isn't posting).
@@ -119,15 +158,106 @@ public class SocialCreditService {
             int newTotal = upsert(r);
             results.add(new UserResult(r.userId(), r.userTag(), r.delta(),
                     r.reasoning(), r.highlights(), newTotal));
-            log(debug, String.format("  %s: delta=%+d, newTotal=%d",
-                    r.userTag(), r.delta(), newTotal));
+            Integer raw = rawDeltas.get(r.userId());
+            log(debug, String.format("  %s: msgs=%d, raw=%s, final=%+d, newTotal=%d",
+                    r.userTag(), msgCounts.getOrDefault(r.userId(), 0),
+                    raw == null ? "n/a" : String.format("%+d", raw),
+                    r.delta(), newTotal));
         }
+        if (debug) saveUserDebugLogs(runAt, results, rawDeltas, msgCounts);
 
         String article = results.isEmpty() ? null : composeNewsReport(results, debug, runAt);
         List<SocialCredit> standings = creditRepo.findAllByOrderByTotalPointsDesc();
 
         log(debug, "Social credit run finished at " + Instant.now());
         return new WeeklyReport(article, standings);
+    }
+
+    // Trims to the most recent `cap` messages, preserving chronological order.
+    private List<Message> capTotal(List<Message> messages, int cap) {
+        return messages.size() > cap
+                ? messages.subList(messages.size() - cap, messages.size())
+                : messages;
+    }
+
+    // One chronological, author-attributed transcript of the whole week. Each
+    // line carries the canonical display name (for the model's comprehension)
+    // and the canonical Discord ID (the echo key we map results back by).
+    private String buildTranscript(List<Message> messages, Map<String, String> roster) {
+        DateTimeFormatter timeFmt = DateTimeFormatter.ofPattern("EEE HH:mm");
+        StringBuilder sb = new StringBuilder();
+        for (Message m : messages) {
+            String canonId = UserConstants.canonicalUserId(m.getAuthor().getId());
+            String name = roster.getOrDefault(canonId, m.getAuthor().getAsTag());
+            sb.append("[").append(m.getTimeCreated().format(timeFmt)).append("] ")
+                    .append(name).append(" (").append(canonId).append("): ")
+                    .append(m.getContentRaw().replace("\n", " ")).append("\n");
+        }
+        return sb.toString();
+    }
+
+    // Single whole-conversation evaluation. Calls OpenRouter, parses the
+    // { "users": [...] } array, and maps each returned id back to a canonical
+    // user. Retries up to MAX_ATTEMPTS on any failure (HTTP error, non-JSON,
+    // missing/unmappable users). Writes a single eval debug-log row for the
+    // terminal outcome (debug mode) and returns null when all attempts fail.
+    private List<UserResult> evaluateConversation(String prompt, Map<String, String> roster,
+                                                  boolean debug, Instant runAt,
+                                                  RunStats stats, String transcript) {
+        String raw = null;
+        String lastError = null;
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                raw = callOpenRouter(prompt, EVAL_MODEL);
+                JSONObject json = extractJson(raw);
+                List<UserResult> results = parseConversationResults(json, roster);
+                if (results.isEmpty()) {
+                    throw new RuntimeException("no valid user results parsed from response");
+                }
+                if (debug) saveEvalDebugLog(runAt, stats, transcript, prompt, raw, null);
+                log(debug, "Evaluation succeeded on attempt " + attempt
+                        + " (" + results.size() + " users scored)");
+                return results;
+            } catch (Exception e) {
+                lastError = e.getMessage();
+                System.out.println("Social credit eval attempt " + attempt + "/" + MAX_ATTEMPTS
+                        + " failed: " + e.getMessage());
+            }
+        }
+        System.out.println("Social credit eval failed after " + MAX_ATTEMPTS
+                + " attempts; aborting. Last error: " + lastError);
+        if (debug) saveEvalDebugLog(runAt, stats, transcript, prompt, raw, lastError);
+        return null;
+    }
+
+    // Parses the model's { "users": [ { id, delta, reasoning, highlights } ] }.
+    // Each id is run through canonicalUserId (in case the model echoed an alias)
+    // and must match a roster user; unrecognised ids are logged and skipped
+    // rather than guessed, and duplicates are dropped (first wins).
+    private List<UserResult> parseConversationResults(JSONObject json, Map<String, String> roster) {
+        JSONArray users = json.optJSONArray("users");
+        if (users == null) {
+            throw new RuntimeException("response missing 'users' array");
+        }
+        List<UserResult> out = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < users.length(); i++) {
+            JSONObject u = users.optJSONObject(i);
+            if (u == null) continue;
+            String rawId = u.optString("id", "").trim();
+            String canonId = UserConstants.canonicalUserId(rawId);
+            if (!roster.containsKey(canonId)) {
+                System.out.println("Social credit: skipping unmappable id '" + rawId
+                        + "' from model response");
+                continue;
+            }
+            if (!seen.add(canonId)) continue; // dedupe — first entry wins
+            int delta = clamp(u.optInt("delta", 0));
+            String reasoning = u.optString("reasoning", "(no reasoning given)");
+            List<String> highlights = parseHighlights(u);
+            out.add(new UserResult(canonId, roster.get(canonId), delta, reasoning, highlights, 0));
+        }
+        return out;
     }
 
     private List<UserResult> applyInactivityAdjustments(List<UserResult> evaluated,
@@ -172,8 +302,12 @@ public class SocialCreditService {
         }
 
         // Add synthetic absentees: any regular who posted nothing this week.
+        // A regular who DID post but whom the model omitted is NOT absent —
+        // they're in msgCounts, so we skip them rather than fabricate a
+        // "posted 0 messages" penalty for someone who actually spoke.
         for (String regularId : UserConstants.REGULAR_USER_IDS) {
             if (evaluatedIds.contains(regularId)) continue;
+            if (msgCounts.containsKey(regularId)) continue;
             String tag = resolveUserTag(channel, regularId);
             log(debug, "  ABSENT: " + tag);
             adjusted.add(new UserResult(
@@ -216,45 +350,6 @@ public class SocialCreditService {
             return creditRepo.findById(userId)
                     .map(SocialCredit::getUserTag)
                     .orElse("user " + userId);
-        }
-    }
-
-    private UserResult evaluateUser(User user, List<Message> messages, boolean debug, Instant runAt) {
-        List<Message> capped = messages.size() > MAX_MESSAGES_PER_USER
-                ? messages.subList(messages.size() - MAX_MESSAGES_PER_USER, messages.size())
-                : messages;
-
-        capped.sort(Comparator.comparing(Message::getTimeCreated));
-        DateTimeFormatter timeFmt = DateTimeFormatter.ofPattern("EEE HH:mm");
-        StringBuilder convo = new StringBuilder();
-        for (Message m : capped) {
-            convo.append("[").append(m.getTimeCreated().format(timeFmt)).append("] ")
-                    .append(m.getContentRaw()).append("\n");
-        }
-
-        boolean stern = UserConstants.STERN_BIAS_IDS.contains(user.getId());
-        String topReactedSection = buildTopReactedSection(findTopReacted(capped));
-        String prompt = buildPrompt(user.getAsTag(), convo.toString(), topReactedSection, stern);
-
-        String raw = null;
-        try {
-            raw = callOpenRouter(prompt, EVAL_MODEL);
-            JSONObject json = extractJson(raw);
-            int delta = clamp(json.getInt("delta"));
-            String reasoning = json.optString("reasoning", "(no reasoning given)");
-            List<String> highlights = parseHighlights(json);
-            if (debug) {
-                saveDebugLog(runAt, user, stern, capped.size(), convo.toString(), prompt, raw,
-                        delta, reasoning, null);
-            }
-            return new UserResult(user.getId(), user.getAsTag(), delta, reasoning, highlights, 0);
-        } catch (Exception e) {
-            System.out.println("Failed to evaluate " + user.getAsTag() + ": " + e.getMessage());
-            if (debug) {
-                saveDebugLog(runAt, user, stern, capped.size(), convo.toString(), prompt, raw,
-                        null, null, e.getMessage());
-            }
-            return null;
         }
     }
 
@@ -432,25 +527,29 @@ public class SocialCreditService {
         return "GOOD";
     }
 
-    private String buildTopReactedSection(List<ReactedMessage> topReacted) {
+    // Global top-reacted section spanning the whole channel for the week. Each
+    // message is attributed to its canonical author (name + id) so the model
+    // knows whose score to weight, since this is no longer a per-user prompt.
+    private String buildTopReactedSection(List<ReactedMessage> topReacted, Map<String, String> roster) {
         if (topReacted.isEmpty()) return "";
         DateTimeFormatter timeFmt = DateTimeFormatter.ofPattern("EEE HH:mm");
         StringBuilder s = new StringBuilder();
         s.append(buildEmojiGlossary(topReacted))
                 .append(":star: TOP-REACTED MESSAGES THIS WEEK\n")
-                .append("The following messages from this user received notable engagement from ")
-                .append("other members. Use the reaction tier to calibrate how much to weight ")
-                .append("each one when scoring. You MUST include each of these messages as a ")
-                .append("highlight in your response so the newspaper editor can write about them.\n\n")
+                .append("The following messages received notable engagement from other members. ")
+                .append("Each is attributed to its author. Use the reaction tier to calibrate how ")
+                .append("much to weight it when scoring that author. You MUST include each of these ")
+                .append("as a highlight for the relevant user so the newspaper editor can write ")
+                .append("about them.\n\n")
                 .append("Tiers:\n")
                 .append("- LEGENDARY (5+ reactions): a major moment. Should drive a noticeably ")
-                .append("positive delta and the highlight should be vivid and quotable so the ")
-                .append("editor gives it top billing.\n")
+                .append("positive delta for its author and the highlight should be vivid and ")
+                .append("quotable so the editor gives it top billing.\n")
                 .append("- BETTER (4 reactions): a clearly popular moment. Notable weight in ")
                 .append("scoring; deserves a dedicated, well-written highlight.\n")
                 .append("- GOOD (3 reactions): modest popularity. Small positive nudge to the ")
-                .append("score; include as a brief highlight.\n")
-                .append("- SELF-REACT (cringe): the user reacted to THEIR OWN message. This is ")
+                .append("author's score; include as a brief highlight.\n")
+                .append("- SELF-REACT (cringe): the author reacted to THEIR OWN message. This is ")
                 .append("cringe regardless of how many others also reacted — it overrides any ")
                 .append("other tier. Apply a small NEGATIVE delta and write a mocking highlight ")
                 .append("calling them out for reacting to themselves. The newspaper editor will ")
@@ -462,12 +561,15 @@ public class SocialCreditService {
                 .append("not goodness. Score it accordingly but still mention it in highlights.\n\n")
                 .append("Messages:\n");
         for (ReactedMessage rm : topReacted) {
+            String canonId = UserConstants.canonicalUserId(rm.message().getAuthor().getId());
+            String name = roster.getOrDefault(canonId, rm.message().getAuthor().getAsTag());
             s.append("- [").append(tierLabel(rm.effectiveCount(), rm.selfReact())).append("] ")
+                    .append("by ").append(name).append(" (").append(canonId).append(") ")
                     .append("[").append(rm.message().getTimeCreated().format(timeFmt)).append("] ")
                     .append(rm.reactionSummary()).append(" (")
                     .append(rm.effectiveCount()).append(" total");
             if (rm.selfReact()) {
-                s.append(" — INCLUDING ONE FROM THE USER THEMSELF");
+                s.append(" — INCLUDING ONE FROM THE AUTHOR THEMSELF");
             }
             s.append(") — \"")
                     .append(rm.message().getContentRaw().replace("\n", " "))
@@ -489,81 +591,168 @@ public class SocialCreditService {
         return out;
     }
 
-    private void saveDebugLog(Instant runAt, User user, boolean stern, int messageCount,
-                              String gathered, String prompt, String llmResponse,
-                              Integer delta, String reasoning, String error) {
+    // One eval debug-log row per run (terminal outcome of the single
+    // whole-conversation call). Mirrors the "__editor__" convention — the call
+    // doesn't map to a single user, so userId is the "__eval__" sentinel and
+    // the per-user columns are left null. Carries the run-level message counts
+    // (fetched / tracked / evaluated / capApplied) so cap pressure is visible.
+    private void saveEvalDebugLog(Instant runAt, RunStats stats, String transcript,
+                                  String prompt, String llmResponse, String error) {
         try {
             debugLogRepo.save(SocialCreditDebugLog.builder()
                     .runAt(runAt)
-                    .userId(user.getId())
-                    .userTag(user.getAsTag())
-                    .sternBias(stern)
-                    .messageCount(messageCount)
-                    .gatheredMessages(gathered)
+                    .userId(EVAL_USER_ID)
+                    .userTag("(conversation eval)")
+                    .sternBias(false)
+                    .messageCount(stats.evaluated())
+                    .fetchedCount(stats.fetched())
+                    .trackedCount(stats.tracked())
+                    .capApplied(stats.capApplied())
+                    .gatheredMessages(transcript)
                     .prompt(prompt)
                     .llmResponse(llmResponse)
-                    .parsedDelta(delta)
-                    .parsedReasoning(reasoning)
+                    .parsedDelta(null)
+                    .parsedReasoning(null)
+                    .rawDelta(null)
+                    .newTotal(null)
                     .error(error)
                     .build());
         } catch (Exception ex) {
-            System.out.println("Failed to save debug log row: " + ex.getMessage());
+            System.out.println("Failed to save eval debug log row: " + ex.getMessage());
         }
+    }
+
+    // One row per scored user (including synthetic absentees), written after
+    // upsert so newTotal is known. Records the full delta story: rawDelta (the
+    // model's score) vs parsedDelta (the final applied score) — their gap is the
+    // inactivity adjustment — plus the running newTotal. This is what to read
+    // when someone's points didn't move as much as expected.
+    private void saveUserDebugLogs(Instant runAt, List<UserResult> results,
+                                   Map<String, Integer> rawDeltas,
+                                   Map<String, Integer> msgCounts) {
+        for (UserResult r : results) {
+            try {
+                Integer raw = rawDeltas.get(r.userId()); // null for synthetic absentees
+                debugLogRepo.save(SocialCreditDebugLog.builder()
+                        .runAt(runAt)
+                        .userId(r.userId())
+                        .userTag(r.userTag())
+                        .sternBias(UserConstants.STERN_BIAS_IDS.contains(r.userId()))
+                        .messageCount(msgCounts.getOrDefault(r.userId(), 0))
+                        .fetchedCount(null)
+                        .trackedCount(null)
+                        .capApplied(null)
+                        .gatheredMessages(null)
+                        .prompt(null)
+                        .llmResponse(null)
+                        .rawDelta(raw)
+                        .parsedDelta(r.delta())     // final delta actually applied
+                        .newTotal(r.newTotal())
+                        .parsedReasoning(buildUserDebugReasoning(r, raw))
+                        .error(null)
+                        .build());
+            } catch (Exception ex) {
+                System.out.println("Failed to save per-user debug log row for "
+                        + r.userTag() + ": " + ex.getMessage());
+            }
+        }
+    }
+
+    // Human-readable breakdown stored in the per-user row's reasoning column:
+    // the inactivity adjustment (if any), the model's reasoning, and highlights.
+    private String buildUserDebugReasoning(UserResult r, Integer rawDelta) {
+        StringBuilder sb = new StringBuilder();
+        if (rawDelta == null) {
+            sb.append("[absentee: no model score; penalty ")
+                    .append(String.format("%+d", r.delta())).append("]\n");
+        } else if (rawDelta != r.delta()) {
+            sb.append(String.format("[adjustment: raw %+d -> final %+d (%+d)]%n",
+                    rawDelta, r.delta(), r.delta() - rawDelta));
+        }
+        sb.append(r.reasoning());
+        if (!r.highlights().isEmpty()) {
+            sb.append("\nHighlights:");
+            for (String h : r.highlights()) {
+                sb.append("\n  - ").append(h);
+            }
+        }
+        return sb.toString();
     }
 
     private void log(boolean debug, String msg) {
         if (debug) System.out.println("[social-credit-debug] " + msg);
     }
 
-    private String buildPrompt(String userTag, String messages, String topReactedSection, boolean stern) {
+    private String buildPrompt(Map<String, String> roster, String transcript, String topReactedSection) {
         StringBuilder p = new StringBuilder();
-        p.append("You are evaluating one week of Discord messages from a single user for a ")
-                .append("playful \"social credit\" score among friends. Read the messages and return ")
-                .append("ONLY a JSON object with this exact shape (no markdown, no prose):\n\n")
+        p.append("You are evaluating ONE WEEK of a private Discord friend group's conversation ")
+                .append("for a playful \"social credit\" score. You are given the entire week as a ")
+                .append("single chronological transcript with every message attributed to its author ")
+                .append("(name and Discord id).\n\n")
+                .append("Judge each user IN CONTEXT. A message's value depends on how the group ")
+                .append("responded to it — laughter, agreement, groans, mockery, being thanked — not ")
+                .append("on the words alone. A genius take and a stupid take can look identical in ")
+                .append("isolation; the group's reaction is the signal. If someone says something and ")
+                .append("the others pile on or call it dumb, score it as the bad take it was; if the ")
+                .append("room lights up and riffs on it, reward it.\n\n")
+                .append("Return ONLY a JSON object with this exact shape (no markdown, no prose):\n\n")
                 .append("{\n")
-                .append("  \"delta\": <integer between -100 and 100>,\n")
-                .append("  \"reasoning\": \"<one sentence explaining the score>\",\n")
-                .append("  \"highlights\": [\"<concrete event 1>\", \"<concrete event 2>\", \"...\"]\n")
+                .append("  \"users\": [\n")
+                .append("    {\n")
+                .append("      \"id\": \"<the Discord id exactly as shown in the transcript>\",\n")
+                .append("      \"delta\": <integer between -100 and 100>,\n")
+                .append("      \"reasoning\": \"<one sentence explaining the score>\",\n")
+                .append("      \"highlights\": [\"<concrete event 1>\", \"<concrete event 2>\", \"...\"]\n")
+                .append("    }\n")
+                .append("  ]\n")
                 .append("}\n\n")
+                .append("- Return exactly one entry per user in the ROSTER who appears in the transcript.\n")
+                .append("- The \"id\" MUST be copied verbatim from the transcript/roster — it is how ")
+                .append("we match your result back to the user. Do NOT invent, merge, rename, or omit ")
+                .append("users.\n\n")
                 .append("Highlights guidance — VERY IMPORTANT, these are used to write a newspaper ")
                 .append("article later:\n")
-                .append("- Return 2 to 4 highlights when there is enough material; 1 is fine for a quiet week.\n")
+                .append("- Return 2 to 4 highlights per user when there is enough material; 1 is fine ")
+                .append("for a quiet week.\n")
                 .append("- Each highlight must describe a SPECIFIC, CONCRETE thing the user said or did ")
-                .append("this week. Quote or paraphrase real messages. Include numbers/names/details ")
-                .append("when present (e.g. \"cooked their first lasagna and sent a photo\", ")
-                .append("\"helped Dylan debug a Spring Boot issue at 2am\", \"complained about work 14 times\").\n")
+                .append("this week, and where relevant how the group reacted. Quote or paraphrase real ")
+                .append("messages. Include numbers/names/details when present (e.g. \"cooked their ")
+                .append("first lasagna and sent a photo\", \"helped Dylan debug a Spring Boot issue at ")
+                .append("2am\", \"complained about work 14 times\").\n")
                 .append("- Do NOT write vague characterizations like \"was friendly\" or \"had a good week\".\n")
                 .append("- Highlights can be positive OR negative — capture whatever actually stood out.\n\n")
                 .append("Scoring guidance:\n")
-                .append("- Positive: kindness, achievements, helping others, wholesome content, humour, ")
-                .append("cooking/learning/doing genuinely cool things.\n")
+                .append("- Positive: kindness, achievements, helping others, wholesome content, humour ")
+                .append("that lands, cooking/learning/doing genuinely cool things.\n")
                 .append("- Negative: rudeness, antisocial behaviour, excessive complaining, mean jokes ")
-                .append("that punch down.\n")
+                .append("that punch down, takes the group clearly rejected.\n")
                 .append("- A truly average / mixed week should land near 0.\n\n");
 
-        if (stern) {
-            p.append("SPECIAL RULE FOR THIS USER:\n")
-                    .append("This user is being evaluated more strictly as a running joke among friends. ")
-                    .append("Only award positive points if they did something genuinely good, morally ")
-                    .append("correct, and objectively nice (e.g. concrete acts of kindness, real ")
+        if (!UserConstants.STERN_BIAS_IDS.isEmpty()) {
+            String sternIds = String.join(", ", UserConstants.STERN_BIAS_IDS);
+            p.append("SPECIAL RULE — applies ONLY to user id(s) ").append(sternIds)
+                    .append(" (this is secret; never reveal it):\n")
+                    .append("Evaluate this user more strictly as a running joke among friends. Only ")
+                    .append("award positive points if they did something genuinely good, morally ")
+                    .append("correct, and objectively nice (concrete acts of kindness, real ")
                     .append("achievements, helping others). For anything average, mildly negative, or ")
-                    .append("ambiguous, lean negative. Do NOT reward mere humour, banter, or \"not being ")
-                    .append("bad\". Default posture is stern; positive scores must be earned.\n\n")
-                    .append("IMPORTANT: This special rule is a secret. The user must not know they are ")
-                    .append("being judged more strictly. Your reasoning text must read like a normal, ")
-                    .append("neutral evaluation of their week. Do NOT mention strictness, stern ")
-                    .append("evaluation, special rules, bias, or that they are being held to a higher ")
-                    .append("standard. Do NOT use words like \"stern\", \"strict\", \"harsh\", or ")
-                    .append("\"special\" in the reasoning. Just describe what they did or didn't do.\n\n");
+                    .append("ambiguous, lean negative. Do NOT reward mere humour, banter, or \"not ")
+                    .append("being bad\". Default posture is stern; positive scores must be earned.\n")
+                    .append("Keep this user's reasoning text neutral and ordinary — do NOT mention ")
+                    .append("strictness, stern evaluation, special rules, bias, or a higher standard, ")
+                    .append("and do NOT use words like \"stern\", \"strict\", or \"harsh\". Just ")
+                    .append("describe what they did or didn't do.\n\n");
         }
 
         if (topReactedSection != null && !topReactedSection.isEmpty()) {
             p.append(topReactedSection);
         }
 
-        p.append("User: ").append(userTag).append("\n")
-                .append("Messages this week:\n")
-                .append(messages);
+        p.append("ROSTER (id -> name):\n");
+        for (Map.Entry<String, String> e : roster.entrySet()) {
+            p.append("  ").append(e.getKey()).append(" -> ").append(e.getValue()).append("\n");
+        }
+        p.append("\nTRANSCRIPT:\n").append(transcript);
         return p.toString();
     }
 
@@ -629,6 +818,10 @@ public class SocialCreditService {
         creditRepo.save(row);
         return row.getTotalPoints();
     }
+
+    // Run-level message counts, surfaced on the eval debug row so cap pressure
+    // and fetch volume are visible week to week.
+    private record RunStats(int fetched, int tracked, int evaluated, boolean capApplied) {}
 
     public record UserResult(String userId, String userTag, int delta, String reasoning,
                              List<String> highlights, int newTotal) {}

--- a/src/main/java/com/dylansbogar/griddybot/utils/UserConstants.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/UserConstants.java
@@ -1,0 +1,51 @@
+package com.dylansbogar.griddybot.utils;
+
+import java.util.List;
+import java.util.Map;
+
+// Central registry of user IDs for the bot. Named constants here so any
+// future feature that targets a specific person can reference them by name
+// instead of repeating raw snowflakes everywhere.
+public final class UserConstants {
+    // The 5 humans in the regular friend group.
+    public static final String MATT_ID    = "187817424337240064";
+    public static final String DYLAN_ID   = "231700435071664128";
+    public static final String DUC_ID     = "175880304525836288";
+    public static final String BRODEY_ID  = "95482653167333376";
+    public static final String DEAN_ID    = "234541539190243328";
+
+    // Matt's alt account. Not a separate person — kept here for the bully
+    // features that target both of his accounts.
+    public static final String OTHER_MATT_ID = "1265821669985878208";
+
+    // Maps alt/alias account IDs to their canonical user ID. The social
+    // credit system attributes messages from an alias to the canonical user
+    // — same score line, same headlines, same evaluation. The alias never
+    // appears in the recap or leaderboard as a separate person.
+    public static final Map<String, String> ACCOUNT_ALIASES = Map.of(
+            OTHER_MATT_ID, MATT_ID
+    );
+
+    // Returns the canonical user ID for a given snowflake. If the input is
+    // a known alias, returns the primary account; otherwise returns input
+    // unchanged.
+    public static String canonicalUserId(String userId) {
+        return ACCOUNT_ALIASES.getOrDefault(userId, userId);
+    }
+
+    // Users targeted by the "bully" features in MessageListener.
+    public static final List<String> BULLY_IDS = List.of(MATT_ID, OTHER_MATT_ID);
+
+    // Users evaluated more strictly by the social credit system.
+    public static final List<String> STERN_BIAS_IDS = List.of(MATT_ID);
+
+    // The 5 regulars whose Discord activity feeds the social credit system.
+    // Anyone outside this list (guests, lurkers, ex-members) is ignored by
+    // the system entirely — their messages don't get evaluated and they
+    // never appear in the recap or leaderboard.
+    public static final List<String> REGULAR_USER_IDS = List.of(
+            MATT_ID, DYLAN_ID, DUC_ID, BRODEY_ID, DEAN_ID
+    );
+
+    private UserConstants() {}
+}


### PR DESCRIPTION
## Features

1. Weekly LLM-evaluated social credit, with a 1920s-newspaper-style recap embed (`📰 The Griddybot Gazette`) posted every Monday 9am
2. `/leaderboard` slash command — ranked standings on demand
3. Stern bias for Matt — secretly judged more harshly; prompt instructs the LLM never to reveal the bias
4. Inactivity tracking — quiet regulars (<30% of group median) get `-10`; absentees get `-20` and a "where were you" headline
5. Reaction tiers `GOOD` / `BETTER` / `LEGENDARY` (3/4/5+ effective reacts) with a `SELF-REACT` cringe override that flips any tier into a roast
6. Custom server emoji glossary (`:OMEGALUL:` vs `:LAUGH:` etc.) injected into prompts so the LLM understands semantic differences
7. Matt's alt account messages merged into his canonical scoreline (one row, one headline)
8. Centralized `UserConstants` with named IDs for all 5 regulars + `ACCOUNT_ALIASES` for future alts
9. Debug mode (`SocialCreditDebug.java`) with short-interval cron, 1-hour window, and a Postgres `social_credit_debug_log` table capturing per-user prompts/responses + the editor pass

`SocialCreditDebug.DEBUG_MODE` is currently `true` — flip to `false` for production.