### PR TITLE
Fix dead social-credit eval model slug (gemini-2.0-flash-001 → gemini-2.5-flash)

### DIFF
--- a/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class SocialCreditService {
     private static final String API_URL = "https://openrouter.ai/api/v1/chat/completions";
     private static final String API_KEY = System.getenv("OPENROUTER_API_KEY");
-    private static final String EVAL_MODEL = "google/gemini-2.0-flash-001";
+    private static final String EVAL_MODEL = "google/gemini-2.5-flash";
     private static final String EDITOR_MODEL = "minimax/minimax-m2.7";
     private static final String EDITOR_USER_ID = "__editor__";
     private static final String EVAL_USER_ID = "__eval__";


### PR DESCRIPTION
## What

`google/gemini-2.0-flash-001` has been removed from OpenRouter, so every social-credit eval attempt 404s with `No endpoints found for google/gemini-2.0-flash-001` and the whole weekly run aborts to the quiet "all quiet" embed. Switch `EVAL_MODEL` to its GA successor `google/gemini-2.5-flash`.

```
Social credit eval attempt 1/3 failed: OpenRouter error: No endpoints found for google/gemini-2.0-flash-001.
...
Social credit eval failed after 3 attempts; aborting.
```

## Change

One-liner: `EVAL_MODEL` `google/gemini-2.0-flash-001` → `google/gemini-2.5-flash`. The editor model (`minimax/minimax-m2.7`) is still a live slug and is unchanged.

## Verification

Confirmed `google/gemini-2.5-flash` is present in OpenRouter's live model catalog (`GET /api/v1/models`), and that `gemini-2.0-flash-001` is absent from it. Not yet verified end-to-end with an authenticated completion call — worth watching the first run's logs (success posts the recap; a fresh error would point to an account data-policy/provider issue rather than the slug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)