### PR TITLE
Show real first names in gazette and leaderboard

### DIFF
--- a/src/main/java/com/dylansbogar/griddybot/commands/LeaderboardCommand.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/LeaderboardCommand.java
@@ -2,6 +2,7 @@ package com.dylansbogar.griddybot.commands;
 
 import com.dylansbogar.griddybot.entities.SocialCredit;
 import com.dylansbogar.griddybot.repositories.SocialCreditRepository;
+import com.dylansbogar.griddybot.utils.UserConstants;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -41,7 +42,8 @@ public class LeaderboardCommand extends ListenerAdapter {
                     ? ""
                     : String.format("  _(last week %+d)_", r.getLastWeekDelta());
             body.append(String.format("%s**%s** — %,d pts%s%n",
-                    medal, r.getUserTag(), r.getTotalPoints(), deltaNote));
+                    medal, UserConstants.displayName(r.getUserId(), r.getUserTag()),
+                    r.getTotalPoints(), deltaNote));
         }
         embed.setDescription(body.toString());
 

--- a/src/main/java/com/dylansbogar/griddybot/utils/EmbedGenerator.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/EmbedGenerator.java
@@ -63,7 +63,8 @@ public class EmbedGenerator {
                     ? ""
                     : String.format("  _(%+d)_", row.getLastWeekDelta());
             sb.append(String.format("%s**%s** — %,d pts%s%n",
-                    medal, row.getUserTag(), row.getTotalPoints(), deltaNote));
+                    medal, UserConstants.displayName(row.getUserId(), row.getUserTag()),
+                    row.getTotalPoints(), deltaNote));
         }
         return sb.toString();
     }

--- a/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/SocialCreditService.java
@@ -126,7 +126,7 @@ public class SocialCreditService {
             String canonId = entry.getKey();
             msgCounts.put(canonId, entry.getValue().size());
             User canonicalUser = resolveCanonicalUser(canonId, entry.getValue(), channel);
-            roster.put(canonId, canonicalUser.getAsTag());
+            roster.put(canonId, UserConstants.displayName(canonId, canonicalUser.getAsTag()));
         }
 
         String transcript = buildTranscript(capped, roster);
@@ -341,7 +341,7 @@ public class SocialCreditService {
         for (String regularId : UserConstants.REGULAR_USER_IDS) {
             if (evaluatedIds.contains(regularId)) continue;
             if (msgCounts.containsKey(regularId)) continue;
-            String tag = resolveUserTag(channel, regularId);
+            String tag = UserConstants.displayName(regularId, resolveUserTag(channel, regularId));
             log(debug, "  ABSENT: " + tag);
             adjusted.add(new UserResult(
                     regularId, tag, ABSENT_PENALTY,

--- a/src/main/java/com/dylansbogar/griddybot/utils/UserConstants.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/UserConstants.java
@@ -33,6 +33,26 @@ public final class UserConstants {
         return ACCOUNT_ALIASES.getOrDefault(userId, userId);
     }
 
+    // Real first names for the regulars, keyed by canonical user ID. Used
+    // everywhere a person is shown to humans (the Griddy Gazette byline and the
+    // leaderboard) so we print "Duc" instead of the raw Discord tag like
+    // "Supayyyer#0000". Anyone not listed here falls back to their tag.
+    public static final Map<String, String> DISPLAY_NAMES = Map.of(
+            MATT_ID,   "Matt",
+            DYLAN_ID,  "Dylan",
+            DUC_ID,    "Duc",
+            BRODEY_ID, "Brodey",
+            DEAN_ID,   "Dean"
+    );
+
+    // Resolves the human-facing name for a user. Returns the mapped real first
+    // name when the (canonicalised) ID is known, otherwise the supplied
+    // fallback — typically the Discord tag from getAsTag(). Aliases resolve to
+    // the canonical person's name (e.g. Matt's alt shows as "Matt").
+    public static String displayName(String userId, String fallbackTag) {
+        return DISPLAY_NAMES.getOrDefault(canonicalUserId(userId), fallbackTag);
+    }
+
     // Users targeted by the "bully" features in MessageListener.
     public static final List<String> BULLY_IDS = List.of(MATT_ID, OTHER_MATT_ID);
 


### PR DESCRIPTION
## Why

In the Griddy Gazette, the same person appeared inconsistently as both `Supayyyer` and `Supayyyer#0000` from week to week.

**Root cause:** every name flowed from `User.getAsTag()`, which returns `username#0000` for accounts on Discord's new username system (the discriminator is the literal `"0000"`). The Java code always emits the `#0000` form. The gazette's prose, however, is written by an LLM editor that non-deterministically decided whether `#0000` was meaningful — sometimes copying it verbatim, sometimes stripping it as noise. That coin-flip is the source of the inconsistency.

## What changed

- **`UserConstants`** — new `DISPLAY_NAMES` map (canonical user ID → real first name) and a `displayName(id, fallbackTag)` helper. Unmapped IDs fall back to the supplied tag, so anyone not in the map reverts to their gamertag as before. Aliases (e.g. Matt's alt) resolve to the canonical person's name.
- **`SocialCreditService`** — roster build and the absentee path now resolve real names. The roster is the single source for the transcript, eval prompt, the `UserResult.userTag`, the editor prompt, *and* the `userTag` written to the DB, so the gazette byline and stored tags both get real names.
- **`LeaderboardCommand`** & **`EmbedGenerator`** — apply `displayName` at display time (keyed by the stored user ID), so even existing DB rows render real first names immediately rather than waiting for the next evaluation.

## Notes

- The leaderboard now shows first names (e.g. `Duc`) instead of tags — this was explicitly requested.
- If an ID can't be linked, it falls back to the Discord tag exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)