### PR TITLE
Match 67 trigger across newlines

### DIFF
--- a/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
@@ -29,8 +29,8 @@ public class MessageListener extends ListenerAdapter {
 //            Pattern.CASE_INSENSITIVE
 //    );
 
-    private static final Pattern sixSevenPattern = Pattern.compile("(?:67)|(?:\\b(?:6|six)\\b.*\\b(?:7|seven)\\b)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern sevenSixPattern = Pattern.compile("(?:76)|(?:\\b(?:7|seven)\\b.*\\b(?:6|six)\\b)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern sixSevenPattern = Pattern.compile("(?:67)|(?:\\b(?:6|six)\\b.*\\b(?:7|seven)\\b)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final Pattern sevenSixPattern = Pattern.compile("(?:76)|(?:\\b(?:7|seven)\\b.*\\b(?:6|six)\\b)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     public final DealHistoryRepository dealHistoryRepository;
     private final OzbargainService ozbargainService;


### PR DESCRIPTION
## What

The `67` GIF trigger didn't fire when the `6` and `7` were separated by a newline (Shift+Enter), e.g.:

```
my fav numbers are 6
and 7
```

## Why

`sixSevenPattern` and `sevenSixPattern` use `.*` for the "anything in between" the two numbers, but were compiled with only `Pattern.CASE_INSENSITIVE`. In Java regex, `.` does **not** match line terminators unless `Pattern.DOTALL` is set, so a newline broke the match. The `cleaned` preprocessing doesn't help — `.trim()` only strips leading/trailing whitespace, so internal newlines survive.

## Fix

Add `Pattern.DOTALL` to both patterns so `.*` spans newlines. Same-line matches and the literal adjacent `67`/`76` branch are unaffected.

## Verification

Ran the exact patterns + `cleaned` logic against test inputs before and after:

| Input | Before | After |
|---|---|---|
| `my fav numbers are 6 and 7` (same line) | MATCH | MATCH |
| `6\nand 7` (Shift+Enter) | NO MATCH | MATCH |
| `6\r\n7` (CRLF) | NO MATCH | MATCH |
| `six\nseven` | NO MATCH | MATCH |
| `six seven` (same line) | MATCH | MATCH |
| `look its 67` (adjacent) | MATCH | MATCH |

🤖 Generated with [Claude Code](https://claude.com/claude-code)