### PR TITLE
Feature/are-you-sure

### DIFF
--- a/src/main/java/com/dylansbogar/griddybot/BotConfig.java
+++ b/src/main/java/com/dylansbogar/griddybot/BotConfig.java
@@ -41,7 +41,7 @@ public class BotConfig {
     private final LastServerRepository lastServerRepo;
     private final OpenRouterService openRouterService;
     private final ConversationService conversationService;
-    private final InstagramService instagramService;
+    private final MediaService mediaService;
 
     private JDA api;
 
@@ -57,8 +57,7 @@ public class BotConfig {
 
         // Each command class is defined here.
         api.addEventListener(
-                new MessageListener(dealHistoryRepo, ozbargainService, openRouterService, conversationService,
-                        instagramService),
+                new MessageListener(dealHistoryRepo, openRouterService, conversationService, mediaService),
                 new ModelCommand(openRouterService),
                 new LastServerCommand(lastServerRepo),
                 new HistoryCommand(conversationService),

--- a/src/main/java/com/dylansbogar/griddybot/BotConfig.java
+++ b/src/main/java/com/dylansbogar/griddybot/BotConfig.java
@@ -67,10 +67,12 @@ public class BotConfig {
                 new EmoteCommand(emoteRepo),
                 new MinecraftCommand(),
                 new YenCommand(yenService),
-                new RemindMeCommand(reminderRepo));
+                new RemindMeCommand(reminderRepo),
+                new PrettySureCommand());
 
         // The text-content of each slash command, which shows to the user upon typing.
         api.updateCommands().addCommands(
+                Commands.slash("prettysure", "Are you sure?"),
                 Commands.slash("coinflip", "Flip a coin!"),
                 Commands.slash("daylist", "Add your current daylist and track your moods.")
                         .addOption(OptionType.STRING, "daylist", "The daylist", true),

--- a/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/MessageListener.java
@@ -9,6 +9,8 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,36 +18,25 @@ public class MessageListener extends ListenerAdapter {
     private static final String ozbargain = "https://www.ozbargain.com.au/node/";
     private static final Pattern thanksPattern = Pattern.compile("thanks griddy", Pattern.CASE_INSENSITIVE);
     private static final Pattern lovePattern = Pattern.compile("^i love (.*)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern instagramReelPattern = Pattern.compile(
-            "https?://(?:www\\.)?instagram\\.com/reel/[A-Za-z0-9_-]+/?(?:\\?[^\\s]*)?",
+    private static final Pattern mediaPattern = Pattern.compile(
+            "https?://(?:www\\.)?(?:instagram\\.com/reels?/[A-Za-z0-9_-]+/?(?:\\?[^\\s]*)?|(?:x\\.com|fxtwitter\\.com)/[A-Za-z0-9_]{1,15}/status/\\d+/?(?:\\?[^\\s]*)?)",
             Pattern.CASE_INSENSITIVE
     );
-    private static final Pattern xPattern = Pattern.compile(
-            "https?://(?:www\\.)?(?:x\\.com|fxtwitter\\.com)/[A-Za-z0-9_]{1,15}/status/\\d+/?(?:\\?[^\\s]*)?",
-            Pattern.CASE_INSENSITIVE);
-
-//    private static final Pattern tiktokPattern = Pattern.compile(
-//            "https?://(?:www\\.)?tiktok\\.com/@[A-Za-z0-9_.]+/video/\\d+/?(?:\\?[^\\s]*)?",
-//            Pattern.CASE_INSENSITIVE
-//    );
-
     private static final Pattern sixSevenPattern = Pattern.compile("(?:67)|(?:\\b(?:6|six)\\b.*\\b(?:7|seven)\\b)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     private static final Pattern sevenSixPattern = Pattern.compile("(?:76)|(?:\\b(?:7|seven)\\b.*\\b(?:6|six)\\b)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
+
     public final DealHistoryRepository dealHistoryRepository;
-    private final OzbargainService ozbargainService;
     private final OpenRouterService openRouterService;
     private final ConversationService conversationService;
-    private final InstagramService instagramService;
+    private final MediaService mediaService;
 
-    public MessageListener(DealHistoryRepository dealHistoryRepository, OzbargainService ozbargainService,
-                           OpenRouterService openRouterService, ConversationService conversationService,
-                           InstagramService instagramService) {
+    public MessageListener(DealHistoryRepository dealHistoryRepository, OpenRouterService openRouterService,
+                           ConversationService conversationService, MediaService mediaService) {
         this.dealHistoryRepository = dealHistoryRepository;
-        this.ozbargainService = ozbargainService;
         this.openRouterService = openRouterService;
         this.conversationService = conversationService;
-        this.instagramService = instagramService;
+        this.mediaService = mediaService;
     }
 
     @Override
@@ -66,43 +57,46 @@ public class MessageListener extends ListenerAdapter {
 
         Matcher thanks = thanksPattern.matcher(content);
         Matcher love = lovePattern.matcher(content);
-        Matcher instagramMatcher = instagramReelPattern.matcher(content);
-        Matcher xMatcher = xPattern.matcher(content);
-//        Matcher tiktokMatcher = tiktokPattern.matcher(content);
+        Matcher mediaMatcher = mediaPattern.matcher(content);
 
         Pattern promptPattern = Pattern.compile("<@!?" + griddyBot.getId() + ">\\s*(.*)");
         Matcher promptMatcher = promptPattern.matcher(event.getMessage().getContentRaw());
 
-        if (instagramMatcher.find()) {
-            String instagramUrl = instagramMatcher.group();
+        if (mediaMatcher.find()) {
+            String url = mediaMatcher.group();
             channel.retrieveMessageById(event.getMessageId()).queue(msg -> {
-                String mediaUrl = instagramService.getMediaUrl(instagramUrl);
+                String mediaUrl = mediaService.getMediaUrl(url);
                 if (mediaUrl != null) {
-                    msg.reply(mediaUrl).queue();
+                    String formattedMessage = "";
+                    msg.delete().queue();
+                    if (url.contains("x.com") || url.contains("fxtwitter.com")) {
+                        formattedMessage = String.format("> %s\n %s posted by <@!%s> at %s",
+                                msg,
+                                mediaUrl,
+                                event.getAuthor().getId(),
+                                event.getMessage().getTimeCreated().atZoneSameInstant(ZoneId.systemDefault())
+                                    .format(DateTimeFormatter.ofPattern("hh:mm a"))
+                                );
+                    } else {
+                        formattedMessage = String.format("> %s\n posted by <@!%s> at %s",
+                                mediaMatcher.replaceAll(mediaUrl),
+                                event.getAuthor().getId(),
+                                event.getMessage().getTimeCreated().atZoneSameInstant(ZoneId.systemDefault())
+                                        .format(DateTimeFormatter.ofPattern("hh:mm a")));
+                    }
+
+                    // Determine whether to reply if applicable, or just send a raw message.
+                    Message referencedMsg = msg.getReferencedMessage();
+                    if (referencedMsg != null) {
+                        referencedMsg.reply(formattedMessage).queue();
+                    } else {
+                        msg.getChannel().sendMessage(formattedMessage).queue();
+                    }
                 } else {
-                    msg.reply("Couldn't retrieve media for that reel, sorry!").queue();
-                }
-            });
-        } else if (xMatcher.find()) {
-            String xUrl = xMatcher.group();
-            channel.retrieveMessageById(event.getMessageId()).queue(msg -> {
-                String mediaUrl = instagramService.getMediaUrl(xUrl);
-                if (mediaUrl != null) {
-                    msg.reply(mediaUrl).queue();
+                    msg.reply("Unable to retrieve media :/").queue();
                 }
             });
         }
-//        else if (tiktokMatcher.find()) {
-//            String tiktokUrl = tiktokMatcher.group();
-//            channel.retrieveMessageById(event.getMessageId()).queue(msg -> {
-//                String mediaUrl = instagramService.getMediaUrl(tiktokUrl);
-//                if (mediaUrl != null) {
-//                    msg.reply(mediaUrl).queue();
-//                } else {
-//                    msg.reply("Couldn't retrieve media for that TikTok, sorry!").queue();
-//                }
-//            });
-//        }
         else if (content.startsWith(ozbargain)) {
             // Extract the full URL and then the id from the ozBargain URL using a regex.
             Pattern fullUrlPattern = Pattern.compile("https?://www\\.ozbargain\\.com\\.au/node/\\d+");

--- a/src/main/java/com/dylansbogar/griddybot/commands/PrettySureCommand.java
+++ b/src/main/java/com/dylansbogar/griddybot/commands/PrettySureCommand.java
@@ -1,0 +1,31 @@
+package com.dylansbogar.griddybot.commands;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.requests.RestAction;
+
+import java.util.List;
+
+public class PrettySureCommand extends ListenerAdapter {
+    private static final List<String> URLs = List.of(
+            "https://klipy.com/gifs/pretty-sure-mark-grayson",
+            "https://tenor.com/view/threw-a-trashbag-are-you-sure-into-space-at-work-invincible-gif-17914355764938628475",
+            "https://klipy.com/gifs/pretty-sure-into-space",
+            "https://klipy.com/gifs/are-you-sure-omni-man-3"
+    );
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (event.getName().equals("prettysure")) {
+            event.deferReply().queue();
+
+            InteractionHook hook = event.getHook();
+            URLs.stream()
+                    .<RestAction<Message>>map(hook::sendMessage)
+                    .reduce((a, b) -> a.flatMap(prev -> b))
+                    .ifPresent(RestAction::queue );
+        }
+    }
+}

--- a/src/main/java/com/dylansbogar/griddybot/utils/MediaService.java
+++ b/src/main/java/com/dylansbogar/griddybot/utils/MediaService.java
@@ -6,7 +6,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
 @Service
-public class InstagramService {
+public class MediaService {
 
     /**
      * Resolves an Instagram reel URL to a direct media URL using yt-dlp --get-url.
@@ -35,7 +35,7 @@ public class InstagramService {
                 return null;
             }
 
-            return String.format("[Here's your video!](%s)", output);
+            return String.format("[video](%s)", output);
 
         } catch (Exception e) {
             System.err.println("Failed to run yt-dlp: " + e.getMessage());


### PR DESCRIPTION
- Created `/prettysure` command.
  - To be used when you need to let someone know how sure you really are.
- Renamed `InstagramService` to `MediaService` as its now used for multiple sources (Instagram and X, soon to be TikTok and YT Shorts)
- Merged all regexes for matching social media into a singular `mediaPattern`.
- Refactored displaying of matching media from `MediaService`:
  - The goal is to delete the original message so we don't see duplicate messages everywhere, but we want to ensure context is preserved. We now delete the original message and respond with a quote containing the message, who sent it and when. If the user was replying to another message, GriddyBot replies to the same message to preserve as much context as possible.
  - When posting media from X, we still display the original link in case context was present in the tweet embed.
  - When posting media from Instagram (and soon to be TikTok), we replace the URL with the new `mediaUrl` generated from `MediaService` as there's no bonus context to be had.